### PR TITLE
Add configurable SNMP engine ID

### DIFF
--- a/bdsSnmpRetrieveAdaptor.py
+++ b/bdsSnmpRetrieveAdaptor.py
@@ -151,7 +151,13 @@ class SnmpFrontEnd:
         self.listeningPort = configDict["listeningPort"]
         self.snmpVersion = configDict["version"]
         self.birthday = time.time()
-        self.snmpEngine = engine.SnmpEngine()
+        engineId = configDict.get('engineId')
+        if engineId:
+            engineId = engineId.replace(':', '')
+            if not engineId.startswith('0x') and not engineId.startswith('0X'):
+                engineId = '0x' + engineId
+            engineId = v2c.OctetString(hexValue=engineId)
+        self.snmpEngine = engine.SnmpEngine(engineId=engineId)
         self.bdsAccess = BdsAccess(cliArgsDict) # Instantiation of the BDS Access Service
         self.oidDb = self.bdsAccess.getOidDb()
         # UDP over IPv4

--- a/bdsSnmpRetrieveAdaptor_v3.yml
+++ b/bdsSnmpRetrieveAdaptor_v3.yml
@@ -10,6 +10,9 @@ bdsSnmpAdapter:
     listeningIP: 0.0.0.0  #SNMP get/getNext listening IP address
     listeningPort: 161 #SNMP get/getNext listening port
     version: 3 # specify snmp version type=str, choices=['2c', '3']
+    # SNMP engine ID uniquely identifies SNMP engine within an administrative
+    # domain. If not set, an automatic value will be generated.
+    engineId: 80:00:C3:8A:04:73:79:73:4e:61:6d:65:31:32:33
     # User-based Security Model (USM) for version 3 configurations:
     # http://snmplabs.com/pysnmp/docs/api-reference.html#security-parameters
     usmUsers:
@@ -23,4 +26,3 @@ bdsSnmpAdapter:
       sysContact: sysContact123@example.com
       sysName: sysName123
       sysLocation: sysLocation123
-      engineId: 80:00:C3:8A:04:73:79:73:4e:61:6d:65_31:32:33

--- a/bdsSnmpTrapAdaptor.py
+++ b/bdsSnmpTrapAdaptor.py
@@ -65,7 +65,13 @@ class asyncioTrapGenerator():
         self.snmpTrapTargets = configDict["snmpTrapTargets"]
         self.snmpTrapPort = configDict["snmpTrapPort"]
         self.trapCounter = 0
-        self.snmpEngine = SnmpEngine()
+        engineId = configDict.get('engineId')
+        if engineId:
+            engineId = engineId.replace(':', '')
+            if not engineId.startswith('0x') and not engineId.startswith('0X'):
+                engineId = '0x' + engineId
+            engineId = OctetString(hexValue=engineId)
+        self.snmpEngine = SnmpEngine(engineId=engineId)
         self.restHttpServerObj = restHttpServerObj
 
     async def sendTrap(self,bdsLogDict):

--- a/bdsSnmpTrapAdaptor.yml
+++ b/bdsSnmpTrapAdaptor.yml
@@ -9,6 +9,10 @@ bdsSnmpAdapter:
     snmpTrapPort: 162 # defines the SNMP trap destination port
     version: 2c # specify snmp version type=str, choices=['2c', '3']
     community: public # v2c community
+    # SNMP engine ID uniquely identifies SNMP engine within an administrative
+    # domain. For SNMPv3 crypto feature to work, the same SNMP engine ID value
+    # should be configured at the TRAP receiver.
+    engineId: 80:00:C3:8A:04:73:79:73:4e:61:6d:65:31:32:33
     # User-based Security Model (USM) for version 3 configurations:
     # http://snmplabs.com/pysnmp/docs/api-reference.html#security-parameters
     usmUsers:


### PR DESCRIPTION
SNMP engine ID value can be configured via configuration files
to both `SnmpRetrieveAdaptor` and `SnmpTrapAdaptor` scripts.