### PR TITLE
Add SNMPv3 auth/encryption configuration and multiple TRAP targets

### DIFF
--- a/bdssnmpadaptor/error.py
+++ b/bdssnmpadaptor/error.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of bdsSnmpAdaptor software.
+#
+# Copyright (C) 2017-2019, RtBrick Inc
+# License: BSD License 2.0
+#
+
+
+class BdsError(Exception):
+    """General BDS error
+    """

--- a/conf/notificator.yml
+++ b/conf/notificator.yml
@@ -5,11 +5,16 @@ bdsSnmpAdapter:
   notificator:
     listeningIP: 0.0.0.0  #REST listening IP address
     listeningPort: 5000 #REST listening port
-    snmpTrapTargets:   #defines the SNMP server, which receives the traps
-      - 127.0.0.1
-    snmpTrapPort: 162 # defines the SNMP trap destination port
-    version: 2c # specify snmp version type=str, choices=['2c', '3']
-    community: public # v2c community
+    snmpTrapTargets:  # map of SNMP trap targets
+      3: # specify snmp version type=str, choices=['1', '2c', '3']
+        testUser1:
+          - 127.0.0.1:  # SNMP manager address
+              162       # SNMP manager port
+      2c: # specify snmp version type=str, choices=['1', '2c', '3']
+        community: public # v2c community
+          - 127.0.0.1:  # SNMP manager address
+              162       # SNMP manager port
+
     # SNMP engine ID uniquely identifies SNMP engine within an administrative
     # domain. For SNMPv3 crypto feature to work, the same SNMP engine ID value
     # should be configured at the TRAP receiver.
@@ -17,8 +22,8 @@ bdsSnmpAdapter:
     # User-based Security Model (USM) for version 3 configurations:
     # http://snmplabs.com/pysnmp/docs/api-reference.html#security-parameters
     usmUsers:
-      - testUser1:
-          authProtocol: usmHMACSHAAuthProtocol
-          authKey: authKey123
-          privProtocol: usmDESPrivProtocol
-          privKey: privkey123
+      testUser1:
+        authProtocol: md5  # md5, sha224, sha256, sha384, sha512, none
+        authKey: authkey123
+        privProtocol: des  # des, 3des, aes128, aes192, aes192blmt, aes256, aes256blmt, none
+        privKey: privkey123

--- a/conf/notificator_v3.yml
+++ b/conf/notificator_v3.yml
@@ -17,11 +17,14 @@ bdsSnmpAdapter:
     # User-based Security Model (USM) for version 3 configurations:
     # http://snmplabs.com/pysnmp/docs/api-reference.html#security-parameters
     usmUsers:
-      - testUser1:
-          authKey: authKey123
-      - testUser2:
-          authKey: authKey123
-          privKey: privKey123
+      testUser1:
+        authKey: authkey123
+        authProtocol: md5  # md5, sha224, sha256, sha384, sha512, none
+      testUser2:
+        authKey: authkey123
+        authProtocol: md5  # md5, sha224, sha256, sha384, sha512, none
+        privKey: privkey123
+        privProtocol: des  # des, 3des, aes128, aes192, aes192blmt, aes256, aes256blmt, none
     staticOidContent:
       sysDesc: bdsSnmpAdaptor v0.5.3
       sysContact: sysContact123@example.com

--- a/conf/responder.yml
+++ b/conf/responder.yml
@@ -13,6 +13,15 @@ bdsSnmpAdapter:
     version: 2c # specify snmp version type=str, choices=['2c', '3']
     community: public # v2c community
     engineId: 80:00:C3:8A:04:73:79:73:4e:61:6d:65:31:32:33
+    usmUsers:
+      testUser1:
+        authKey: authkey123
+        authProtocol: md5  # md5, sha224, sha256, sha384, sha512, none
+      testUser2:
+        authKey: authkey123
+        authProtocol: md5  # md5, sha224, sha256, sha384, sha512, none
+        privKey: privkey123
+        privProtocol: des  # des, 3des, aes128, aes192, aes192blmt, aes256, aes256blmt, none
     staticOidContent:
       sysDesc: l2.pod2.nbg2.rtbrick.net
       sysContact: stefan@rtbrick.com


### PR DESCRIPTION
Added a handful of SNMP authenticator and privacy protocols to both command responder and notification originator.

Added the ability to configure multiple USM users.

Notification originator refactored to allow for sending TRAPs to multiple targets using potentially different SNMP versions and credentials (notification sender seems not to be fully implemented to date though).
