### PR TITLE
Fix undefined names in mapping functions modules

### DIFF
--- a/bdssnmpadaptor/mapping_modules/confd_global_interface_container.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_interface_container.py
@@ -150,7 +150,7 @@ class confd_global_interface_container(object):
                 ifName = bdsJsonObject["attribute"]["interface_name"]
                 index = BdsMappingFunctions.ifIndexFromIfName(ifName)
                 ifPhysicalLocation = BdsMappingFunctions.stripIfPrefixFromIfName(ifName)
-                ifSpeed = IFSPEED_LAMBDA(bdsJsonObject["attribute"]["bandwidth"])))
+                ifSpeed = IFSPEED_LAMBDA(bdsJsonObject["attribute"]["bandwidth"])
                 if ifSpeed  == 100000000:
                     ifGigEtherName = "hundredGe-" + BdsMappingFunctions.stripIfPrefixFromIfName(ifName)
                 elif ifSpeed  == 10000000:

--- a/bdssnmpadaptor/mapping_modules/confd_global_interface_physical.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_interface_physical.py
@@ -1,6 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of bdsSnmpAdaptor software.
+#
+# Copyright (C) 2017-2019, RtBrick Inc
+# License: BSD License 2.0
+#
 import binascii
 import struct
 import time
+
+from pysnmp.proto.rfc1902 import Gauge32
+from pysnmp.proto.rfc1902 import Integer32
+from pysnmp.proto.rfc1902 import OctetString
+from pysnmp.proto.rfc1902 import TimeTicks
 
 from bdssnmpadaptor.mapping_functions import BdsMappingFunctions
 from bdssnmpadaptor.oidDb import OidDbItem

--- a/bdssnmpadaptor/mapping_modules/confd_global_startup_status_confd.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_startup_status_confd.py
@@ -5,6 +5,9 @@
 # Copyright (C) 2017-2019, RtBrick Inc
 # License: BSD License 2.0
 #
+from pysnmp.proto.rfc1902 import Integer32
+from pysnmp.proto.rfc1902 import OctetString
+
 from bdssnmpadaptor.oidDb import OidDbItem
 
 # running(1),

--- a/bdssnmpadaptor/mapping_modules/confd_local_system_software_info_confd.py
+++ b/bdssnmpadaptor/mapping_modules/confd_local_system_software_info_confd.py
@@ -5,6 +5,8 @@
 # Copyright (C) 2017-2019, RtBrick Inc
 # License: BSD License 2.0
 #
+from pysnmp.proto.rfc1902 import OctetString
+
 from bdssnmpadaptor.mapping_functions import BdsMappingFunctions
 from bdssnmpadaptor.oidDb import OidDbItem
 

--- a/bdssnmpadaptor/mapping_modules/ffwd_default_interface_logical.py
+++ b/bdssnmpadaptor/mapping_modules/ffwd_default_interface_logical.py
@@ -5,6 +5,9 @@
 # Copyright (C) 2017-2019, RtBrick Inc
 # License: BSD License 2.0
 #
+from pysnmp.proto.rfc1902 import Integer32
+from pysnmp.proto.rfc1902 import OctetString
+
 from bdssnmpadaptor.mapping_functions import BdsMappingFunctions
 from bdssnmpadaptor.oidDb import OidDbItem
 

--- a/bdssnmpadaptor/mapping_modules/fwdd_global_interface_physical_statistics.py
+++ b/bdssnmpadaptor/mapping_modules/fwdd_global_interface_physical_statistics.py
@@ -5,11 +5,14 @@
 # Copyright (C) 2017-2019, RtBrick Inc
 # License: BSD License 2.0
 #
+import binascii
+import struct
+
+from pysnmp.proto.rfc1902 import Counter32
+from pysnmp.proto.rfc1902 import Gauge32
+
 from bdssnmpadaptor.mapping_functions import BdsMappingFunctions
 from bdssnmpadaptor.oidDb import OidDbItem
-
-import struct
-import binascii
 
 HEX_STRING_LAMBDA = lambda x: int(x, 16)
 

--- a/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
+++ b/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
@@ -1,6 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of bdsSnmpAdaptor software.
+#
+# Copyright (C) 2017-2019, RtBrick Inc
+# License: BSD License 2.0
+#
 import binascii
 import struct
 import time
+
+from pysnmp.proto.rfc1902 import Gauge32
+from pysnmp.proto.rfc1902 import Integer32
+from pysnmp.proto.rfc1902 import OctetString
+from pysnmp.proto.rfc1902 import TimeTicks
 
 from bdssnmpadaptor.mapping_functions import BdsMappingFunctions
 from bdssnmpadaptor.oidDb import OidDbItem
@@ -8,6 +20,7 @@ from bdssnmpadaptor.oidDb import OidDbItem
 IFTYPEMAP = {
     1: 6  # ethernet-csmacd(6)
 }
+
 IFOPERSTATUSMAP = {
     0: 2,  # down(2)
     1: 1,  # up(1),       -- ready to pass packets


### PR DESCRIPTION
This PR fixes forgotten imports of SNMP base types and fixes a syntax error in one of the modules.