### PR TITLE
Add conventional sysv init scripts

### DIFF
--- a/sysvinit/generic/bds-snmp-notificator
+++ b/sysvinit/generic/bds-snmp-notificator
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+NAME=bds-snmp-notificator
+DESC="BDS SNMP Notification Originator"
+PIDFILE=/run/bds-snmp-notificator.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+DAEMON=$NAME
+DAEMONOPTS="--config /etc/bds-snmp-adaptor/notificator.yml --pidfile $PIDFILE --daemonize"
+
+
+case "$1" in
+start)
+    printf "%-50s" "Starting $NAME..."
+    $DAEMON $DAEMONOPTS
+    if [ $? ]; then
+        printf "%s\n" "Ok"
+    else
+        printf "%s\n" "Fail"
+    fi
+;;
+status)
+        printf "%-50s" "Checking $NAME..."
+        if [ -f $PIDFILE ]; then
+            PID=`cat $PIDFILE`
+            if [ -z "`ps axf | grep ${PID} | grep -v grep`" ]; then
+                printf "%s\n" "Process dead but pidfile exists"
+            else
+                echo "Running"
+            fi
+        else
+            printf "%s\n" "Service not running"
+        fi
+;;
+stop)
+        printf "%-50s" "Stopping $NAME"
+        PID=`cat $PIDFILE`
+        if [ -f $PIDFILE ]; then
+            kill -HUP $PID
+            printf "%s\n" "Ok"
+            rm -f $PIDFILE
+        else
+            printf "%s\n" "pidfile not found"
+        fi
+;;
+
+restart)
+  	$0 stop
+  	$0 start
+;;
+
+*)
+        echo "Usage: $0 {status|start|stop|restart}"
+        exit 1
+esac

--- a/sysvinit/generic/bds-snmp-responder
+++ b/sysvinit/generic/bds-snmp-responder
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+NAME=bds-snmp-responder
+DESC="BDS SNMP Command Responder"
+PIDFILE=/run/bds-snmp-responder.pid
+SCRIPTNAME=/etc/init.d/$NAME
+
+DAEMON=$NAME
+DAEMONOPTS="--config /etc/bds-snmp-adaptor/responder.yml --pidfile $PIDFILE --daemonize"
+
+
+case "$1" in
+start)
+    printf "%-50s" "Starting $NAME..."
+    $DAEMON $DAEMONOPTS
+    if [ $? ]; then
+        printf "%s\n" "Ok"
+    else
+        printf "%s\n" "Fail"
+    fi
+;;
+status)
+        printf "%-50s" "Checking $NAME..."
+        if [ -f $PIDFILE ]; then
+            PID=`cat $PIDFILE`
+            if [ -z "`ps axf | grep ${PID} | grep -v grep`" ]; then
+                printf "%s\n" "Process dead but pidfile exists"
+            else
+                echo "Running"
+            fi
+        else
+            printf "%s\n" "Service not running"
+        fi
+;;
+stop)
+        printf "%-50s" "Stopping $NAME"
+        PID=`cat $PIDFILE`
+        if [ -f $PIDFILE ]; then
+            kill -HUP $PID
+            printf "%s\n" "Ok"
+            rm -f $PIDFILE
+        else
+            printf "%s\n" "pidfile not found"
+        fi
+;;
+
+restart)
+  	$0 stop
+  	$0 start
+;;
+
+*)
+        echo "Usage: $0 {status|start|stop|restart}"
+        exit 1
+esac


### PR DESCRIPTION
It turned out that ONL startup harness is glitchy. This commit
adds functionally similar init scripts, just with minimum external
dependencies.