### PR TITLE
01 - Remove obsolete OID DB interfaces

### DIFF
--- a/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
+++ b/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
@@ -9,10 +9,7 @@ import binascii
 import struct
 import time
 
-from pysnmp.proto.rfc1902 import Integer32
-
 from bdssnmpadaptor import mapping_functions
-from bdssnmpadaptor.oidDb import OidDbItem
 
 IFTYPEMAP = {
     1: 6  # ethernet-csmacd(6)
@@ -136,13 +133,8 @@ class LldpdGlobalLldpIntfStatus(object):
 
         with targetOidDb.module(__name__) as add:
 
-            targetOidDb.insertOid(
-                newOidItem=OidDbItem(
-                    bdsMappingFunc=__name__,
-                    oid='1.3.6.1.2.1.2.1.0',
-                    name='ifIndex',
-                    pysnmpBaseType=Integer32,
-                    value=len(bdsJsonResponseDict['objects'])))
+            add('IF-MIB', 'ifNumber', 0,
+                value=len(bdsJsonResponseDict['objects']))
 
             # targetOidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
 

--- a/tests/unit/test_oiddb.py
+++ b/tests/unit/test_oiddb.py
@@ -21,15 +21,12 @@ class OidDbItemTestCase(unittest.TestCase):
             bdsMappingFunc='interface_container',
             oid='1.3.6.7.8',
             name='ifIndex',
-            pysnmpBaseType=rfc1902.OctetString,
-            pysnmpRepresentation='hexValue',
-            value='123456789',
+            value=rfc1902.OctetString(hexValue='123456789'),
         )
 
         self.assertEqual('interface_container', oid.bdsMappingFunc)
         self.assertEqual(rfc1902.ObjectIdentifier('1.3.6.7.8'), oid.oid)
         self.assertEqual('ifIndex', oid.name)
-        self.assertEqual(rfc1902.OctetString, oid.pysnmpBaseType)
         self.assertEqual(b'\x124Vx\x90', oid.value)
 
     def test___lt__(self):
@@ -51,8 +48,7 @@ class OidDbItemTestCase(unittest.TestCase):
             bdsMappingFunc='interface_container',
             oid='1.3.6.7.8',
             name='ifIndex',
-            pysnmpBaseType=rfc1902.OctetString,
-            value='0x123456789',
+            value=rfc1902.OctetString(hexValue='123456789'),
         )
 
         self.assertIsInstance(str(oid), str)


### PR DESCRIPTION
With the migration from `.insertOid()` to `.add()` methods, the low-level args are not used anymore and can be removed for clarity and simplification.