### PR TITLE
05 - Add OID DB data expiration feature

### DIFF
--- a/bdssnmpadaptor/access.py
+++ b/bdssnmpadaptor/access.py
@@ -17,7 +17,7 @@ from bdssnmpadaptor.log import set_logging
 from bdssnmpadaptor.mapping_modules import confd_global_interface_physical
 from bdssnmpadaptor.mapping_modules import confd_global_startup_status_confd
 from bdssnmpadaptor.mapping_modules import confd_local_system_software_info_confd
-from bdssnmpadaptor.oidDb import OidDb
+from bdssnmpadaptor.oid_db import OidDb
 from bdssnmpadaptor.mapping_modules.predefined_oids import StaticAndPredefinedOids
 
 BIRTHDAY = time.time()
@@ -79,12 +79,11 @@ class BdsAccess(object):
 
         self.staticOidDict = configDict['responder']['staticOidContent']
 
-        # TODO: expire stale objects from the DB
         self._oidDb = OidDb(cliArgsDict)
 
         # used for hashing numbers of objects and hash over sequence numbers
         # TODO: expire this
-        self.bdsIds = collections.defaultdict(list)
+        self._bdsIds = collections.defaultdict(list)
 
         # 'logging': 'warning'
         # do more stuff here. e.g. connectivity checks etc
@@ -184,7 +183,7 @@ class BdsAccess(object):
                 self.moduleLogger.debug(
                     f'bdsResponses[{tableKey}] {bdsResponse}')
 
-                bdsId = self.bdsIds[bdsReqKey]
+                bdsId = self._bdsIds[bdsReqKey]
 
                 try:
                     mappingfunc.setOids(
@@ -195,7 +194,7 @@ class BdsAccess(object):
                         f'failed at populating OID DB from BDS response: {exc}')
                     continue
 
-                self.bdsIds[bdsReqKey] = [
+                self._bdsIds[bdsReqKey] = [
                     obj['sequence'] for obj in bdsResponse['objects']
                 ]
 

--- a/bdssnmpadaptor/access.py
+++ b/bdssnmpadaptor/access.py
@@ -168,7 +168,7 @@ class BdsAccess(object):
 
             try:
                 StaticAndPredefinedOids.setOids(
-                    self.staticOidDict, self.oidDb, [], 0)
+                    self.oidDb, self.staticOidDict, [], 0)
 
             except Exception as exc:
                 self.moduleLogger.error(
@@ -204,7 +204,7 @@ class BdsAccess(object):
 
                 try:
                     mappingfunc.setOids(
-                        responseJsonDict, self.oidDb, tableSequenceList, BIRTHDAY)
+                        self.oidDb, responseJsonDict, tableSequenceList, BIRTHDAY)
 
                 except Exception as exc:
                     self.moduleLogger.error(

--- a/bdssnmpadaptor/commands/adaptor.py
+++ b/bdssnmpadaptor/commands/adaptor.py
@@ -70,7 +70,7 @@ See https://www.rtbrick.com for RtBrick product information.
     bdsAccess = BdsAccess(cliArgsDict)
 
     mibController = MibInstrumController()
-    mibController.setOidDbAndLogger(bdsAccess.getOidDb(), cliArgsDict)
+    mibController.setOidDbAndLogger(bdsAccess.oidDb, cliArgsDict)
 
     SnmpCommandResponder(cliArgsDict, mibController)
 

--- a/bdssnmpadaptor/mapping_modules/confd_global_interface_container.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_interface_container.py
@@ -96,8 +96,6 @@ class ConfdGlobalInterfaceContainer(object):
             add('IF-MIB', 'ifNumber', 0,
                 value=len(bdsData['objects']))
 
-            # oidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
-
             for i, bdsObject in enumerate(bdsData['objects']):
                 currentId = bdsObject['sequence']
 

--- a/bdssnmpadaptor/mapping_modules/confd_global_interface_container.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_interface_container.py
@@ -22,13 +22,11 @@ IFOPERSTATUSMAP = {
     3: 3  # testing(3)   -- in some test mode
 }
 
-bigEndianFloatStruct = struct.Struct('>f')
-littleEndianShortStruct = struct.Struct('<h')
-
 IFMTU_LAMBDA = lambda x: int(
-    littleEndianShortStruct.unpack(binascii.unhexlify(x))[0])
+    struct.Struct('<h').unpack(binascii.unhexlify(x))[0])
+
 IFSPEED_LAMBDA = lambda x: int(
-    bigEndianFloatStruct.unpack(binascii.unhexlify(x))[0] / 1000000 * 8)
+    struct.Struct('>f').unpack(binascii.unhexlify(x))[0] / 1000000 * 8)
 
 
 # HEX_STRING_LAMBDA = lambda x : int(x,16)
@@ -36,22 +34,19 @@ IFSPEED_LAMBDA = lambda x: int(
 
 
 class ConfdGlobalInterfaceContainer(object):
-    """Interface container
+    """Implement SNMP IF-MIB for container BDS interfaces.
+
+    Populates SNMP managed objects of SNMP `IF-MIB` module from
+    `global.interface.container` BDS table.
 
     Notes
     -----
 
-    root@l2-pod2:~#     curl -X POST -H "Content-Type: application/json" -H "Accept: */*" -H "connection: close"\
-    >         -H "Accept-Encoding: application/json"\
-    >         -d '{"table": {"table_name": "global.interface.container"}}'\
-    >         "http://10.0.3.10:2002/bds/table/walk?format=raw" | jq '.'
-      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                     Dload  Upload   Total   Spent    Left  Speed
-    100 18629    0 18574  100    55  2826k   8570 --:--:-- --:--:-- --:--:-- 3023k
+    Expected input:
+
+    .. code-block:: json
+
     {
-      "table": {
-        "table_name": "global.interface.container"
-      },
       "objects": [
         {
           "sequence": 200197,
@@ -69,67 +64,26 @@ class ConfdGlobalInterfaceContainer(object):
               "ifp-0/0/1"
             ]
           }
-        },
-        {
-          "sequence": 200198,
-          "update": true,
-          "attribute": {
-            "interface_name": "ifc-0/0/0/2",
-            "interface_description": "Container interface for ifp-0/0/2",
-            "encapsulation_type": "01",
-            "bandwidth": "4e9502f9",
-            "layer2_mtu": "f205",
-            "admin_status": "01",
-            "link_status": "01",
-            "mac_address": "b86a97a59202",
-            "physical_interfaces": [
-              "ifp-0/0/2"
-            ]
-          }
-        },
-        {
-          "sequence": 200061,
-          "update": true,
-          "attribute": {
-            "interface_name": "ifc-0/0/0/3",
-            "interface_description": "Container interface for ifp-0/0/3",
-            "encapsulation_type": "01",
-            "bandwidth": "4e9502f9",
-            "layer2_mtu": "f205",
-            "admin_status": "01",
-            "link_status": "01",
-            "mac_address": "b86a97a59203",
-            "physical_interfaces": [
-              "ifp-0/0/3"
-            ]
-          }
-        },
-
-
-        5
-        ifTableLastChange	TICKS	ReadOnly	.1.3.6.1.2.1.31.1.5
-        The value of sysUpTime at the time of the last creation or
-        deletion of an entry in the ifTable.  If the number of
-        entries has been unchanged since the last re-initialization
-        of the local network management subsystem, then this object
-        contains a zero value.
-        6
-        ifStackLastChange	TICKS	ReadOnly	.1.3.6.1.2.1.31.1.6
-        The value of sysUpTime at the time of the last change of
-        the (whole) interface stack.  A change of the interface
-        stack is defined to be any creation, deletion, or change in
-        value of any instance of ifStackStatus.  If the interface
-        stack has been unchanged since the last re-initialization of
-        the local network management subsystem, then this object
-        contains a zero value.
+        }
+      ]
+    }
     """
 
     @classmethod
     def setOids(cls, oidDb, bdsData, bdsIds, birthday):
-        """Initialize OID DB with BDS information.
+        """Populates OID DB with BDS information.
 
         Takes known objects from JSON document, puts them into
         the OID DB as specific MIB managed objects.
+
+        Args:
+            oidDb (OidDb): OID DB instance to work on
+            bdsData (dict): BDS information to put into OID DB
+            bdsIds (list): list of last known BDS record sequence IDs
+            birthday (float): timestamp of system initialization
+
+        Raises:
+            BdsError: on OID DB population error
         """
 
         newBdsIds = [obj['sequence'] for obj in bdsData['objects']]

--- a/bdssnmpadaptor/mapping_modules/confd_global_interface_physical.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_interface_physical.py
@@ -103,7 +103,6 @@ class ConfdGlobalInterfacePhysical(object):
             add('IF-MIB', 'ifNumber', 0,
                 value=len(bdsData['objects']))
 
-            # oidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
             for i, bdsJsonObject in enumerate(bdsData['objects']):
 
                 currentId = bdsJsonObject['sequence']

--- a/bdssnmpadaptor/mapping_modules/confd_global_interface_physical.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_interface_physical.py
@@ -22,103 +22,74 @@ IFOPERSTATUSMAP = {
     3: 3  # testing(3)   -- in some test mode
 }
 
-bigEndianFloatStruct = struct.Struct('>f')
-littleEndianShortStruct = struct.Struct('<h')
 IFMTU_LAMBDA = lambda x: int(
-    littleEndianShortStruct.unpack(binascii.unhexlify(x))[0])
+    struct.Struct('<h').unpack(binascii.unhexlify(x))[0])
 IFSPEED_LAMBDA = lambda x: int(
-    round(bigEndianFloatStruct.unpack(binascii.unhexlify(x))[0] / 1000) / 1000000 * 8) * 1000
+    round(struct.Struct('>f').unpack(binascii.unhexlify(x))[0] / 1000) / 1000000 * 8) * 1000
 
-
-# HEX_STRING_LAMBDA = lambda x : int(x,16)
-# IFMTU_LAMBDA = lambda x : int(''.join([m[2:4]+m[0:2] for m in [x[i:i+4] for i in range(0,len(x),4)]]),16)
 
 class ConfdGlobalInterfacePhysical(object):
-    """
-        curl -X POST -H "Content-Type: application/json" -H "Accept: */*" -H "connection: close"\
-                       -H "Accept-Encoding: application/json"\
-                       -d '{"table": {"table_name": "global.interface.physical"}}'\
-                       "http://10.0.3.10:2002/bds/table/walk?format=raw" | jq '.'
+    """Implement SNMP IF-MIB for physical BDS interfaces.
 
+    Populates SNMP managed objects of SNMP `IF-MIB` module from
+    `global.interface.physical` BDS table.
+
+    Notes
+    -----
+
+    Expected input:
+
+    .. code-block:: json
+
+    {
+      "objects": [
         {
-          "objects": [
-            {
-              "attribute": {
-                "supported_breakout_modes": [
-                  "4x1G"
-                ],
-                "configured_layer2_mtu": "dc05",
-                "supported_max_layer2_mtu": "f205",
-                "supported_min_layer2_mtu": "4000",
-                "supported_auto_negotiation": "01",
-                "configured_bandwidth": "4e9502f9",
-                "default_bandwidth": "4e9502f9",
-                "supported_bandwidths": [
-                  "10.000 Gbps",
-                  "1.000 Gbps"
-                ],
-                "interface_name": "ifp-0/0/1",
-                "interface_description": "Physical interface #1 from node 0, chip 0",
-                "interface_type": "01",
-                "bandwidth": "4e9502f9",
-                "layer2_mtu": "f205",
-                "mac_address": "b86a97a59201",
-                "admin_status": "01",
-                "link_status": "01"
-              },
-              "update": true,
-              "sequence": 200197
-            },
-            {
-              "attribute": {
-                "supported_breakout_modes": [
-                  "4x1G"
-                ],
-                "configured_layer2_mtu": "dc05",
-                "supported_max_layer2_mtu": "f205",
-                "supported_min_layer2_mtu": "4000",
-                "supported_auto_negotiation": "01",
-                "configured_bandwidth": "4e9502f9",
-                "default_bandwidth": "4e9502f9",
-                "supported_bandwidths": [
-                  "10.000 Gbps",
-                  "1.000 Gbps"
-                ],
-                "interface_name": "ifp-0/0/2",
-                "interface_description": "Physical interface #2 from node 0, chip 0",
-                "interface_type": "01",
-                "bandwidth": "4e9502f9",
-                "layer2_mtu": "f205",
-                "mac_address": "b86a97a59202",
-                "admin_status": "01",
-                "link_status": "01"
-              },
-              "update": true,
-              "sequence": 200198
-            },
-
-
-        5
-        ifTableLastChange	TICKS	ReadOnly	.1.3.6.1.2.1.31.1.5
-        The value of sysUpTime at the time of the last creation or
-        deletion of an entry in the ifTable.  If the number of
-        entries has been unchanged since the last re-initialization
-        of the local network management subsystem, then this object
-        contains a zero value.
-        6
-        ifStackLastChange	TICKS	ReadOnly	.1.3.6.1.2.1.31.1.6
-        The value of sysUpTime at the time of the last change of
-        the (whole) interface stack.  A change of the interface
-        stack is defined to be any creation, deletion, or change in
-        value of any instance of ifStackStatus.  If the interface
-        stack has been unchanged since the last re-initialization of
-        the local network management subsystem, then this object
-        contains a zero value.
-
+          "attribute": {
+            "supported_breakout_modes": [
+              "4x1G"
+            ],
+            "configured_layer2_mtu": "dc05",
+            "supported_max_layer2_mtu": "f205",
+            "supported_min_layer2_mtu": "4000",
+            "supported_auto_negotiation": "01",
+            "configured_bandwidth": "4e9502f9",
+            "default_bandwidth": "4e9502f9",
+            "supported_bandwidths": [
+              "10.000 Gbps",
+              "1.000 Gbps"
+            ],
+            "interface_name": "ifp-0/0/1",
+            "interface_description": "Physical interface #1 from node 0, chip 0",
+            "interface_type": "01",
+            "bandwidth": "4e9502f9",
+            "layer2_mtu": "f205",
+            "mac_address": "b86a97a59201",
+            "admin_status": "01",
+            "link_status": "01"
+          },
+          "update": true,
+          "sequence": 200197
+        }
+      ]
+    }
     """
 
     @classmethod
     def setOids(cls, oidDb, bdsData, bdsIds, birthday):
+        """Populates OID DB with BDS information.
+
+        Takes known objects from JSON document, puts them into
+        the OID DB as specific MIB managed objects.
+
+        Args:
+            oidDb (OidDb): OID DB instance to work on
+            bdsData (dict): BDS information to put into OID DB
+            bdsIds (list): list of last known BDS record sequence IDs
+            birthday (float): timestamp of system initialization
+
+        Raises:
+            BdsError: on OID DB population error
+        """
 
         newBdsIds = [obj['sequence'] for obj in bdsData['objects']]
 

--- a/bdssnmpadaptor/mapping_modules/confd_global_startup_status_confd.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_startup_status_confd.py
@@ -18,25 +18,50 @@ HRSWRUNSTATUSMAP = {
 
 
 class ConfdGlobalStartupStatusConfd(object):
-    """Startup status
+    """Implement SNMP HOST-RESOURCES-MIB for BDS system.
 
-    curl -X POST -H "Content-Type: application/json" -H "Accept: */*" -v -H "connection: close"
-         -H "Accept-Encoding: application/json"
-         -d '{"table": {"table_name": "global.startup.status.confd"}}' "http://10.0.3.50:2002/bds/table/walk?format=raw"
+    Populates SNMP managed objects of SNMP `HOST-RESOURCES-MIB` module from
+    `global.startup.status.confd` BDS table.
 
-    { "table": { "table_name": "global.startup.status.confd" },
+    Notes
+    -----
+
+    Expected input:
+
+    .. code-block:: json
+
+    {
       "objects": [
-         { "sequence": 5, "update": true, "attribute":
-           { "module_name": "bd", "startup_status": "02", "up_time": "a03d475c642e696e", "bd_name": "confd" } },
-         { "sequence": 6, "update": true, "attribute":
-           { "module_name": "bds", "startup_status": "02", "up_time": "a03d475c2e696e63", "bd_name": "confd" } },
-         { "sequence": 3, "update": true, "attribute":
-           { "module_name": "lwip", "startup_status": "02", "up_time": "a03d475c6c6f672e", "bd_name": "confd" } } ] }
-
+        {
+          "sequence": 5,
+          "update": true,
+          "attribute": {
+            "module_name": "bd",
+            "startup_status": "02",
+            "up_time": "a03d475c642e696e",
+            "bd_name": "confd"
+          }
+        }
+      ]
+    }
     """
 
     @classmethod
     def setOids(cls, oidDb, bdsData, bdsIds, birthday):
+        """Populates OID DB with BDS information.
+
+        Takes known objects from JSON document, puts them into
+        the OID DB as specific MIB managed objects.
+
+        Args:
+            oidDb (OidDb): OID DB instance to work on
+            bdsData (dict): BDS information to put into OID DB
+            bdsIds (list): list of last known BDS record sequence IDs
+            birthday (float): timestamp of system initialization
+
+        Raises:
+            BdsError: on OID DB population error
+        """
 
         with oidDb.module(__name__) as add:
 

--- a/bdssnmpadaptor/mapping_modules/confd_global_startup_status_confd.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_startup_status_confd.py
@@ -36,12 +36,11 @@ class ConfdGlobalStartupStatusConfd(object):
     """
 
     @classmethod
-    def setOids(cls, bdsJsonResponseDict, targetOidDb,
-                tableSequenceList, birthday):
+    def setOids(cls, oidDb, bdsData, bdsIds, birthday):
 
-        with targetOidDb.module(__name__) as add:
+        with oidDb.module(__name__) as add:
 
-            for index0, bdsJsonObject in enumerate(bdsJsonResponseDict['objects']):
+            for index0, bdsJsonObject in enumerate(bdsData['objects']):
                 index = index0 + 1
 
                 add('HOST-RESOURCES-MIB', 'hrSWOSIndex', index, value=index)

--- a/bdssnmpadaptor/mapping_modules/confd_local_system_software_info_confd.py
+++ b/bdssnmpadaptor/mapping_modules/confd_local_system_software_info_confd.py
@@ -10,11 +10,55 @@ from bdssnmpadaptor import mapping_functions
 
 
 class ConfdLocalSystemSoftwareInfoConfd(object):
-    """Local system software information
+    """Implement SNMP SNMPv2-MIB for BDS system.
+
+    Populates SNMP managed objects of SNMP `SNMPv2-MIB` module from
+    `local.system.software.info.confd` BDS table.
+
+    Notes
+    -----
+
+    Expected input:
+
+    .. code-block:: json
+
+    {
+      "objects": [
+        {
+          "sequence": 3,
+          "update": true,
+          "timestamp": "Tue Apr 09 11:44:57 GMT +0000 2019",
+          "attribute": {
+            "library": "bd",
+            "commit_id": "8d5cc5a8ca9324154568470b1e8be20df57bedb3",
+            "commit_date": "Fri Mar 22 12:47:37 2019 +0530",
+            "package_date": "Mon, 08 Apr 2019 23:31:43 +0000",
+            "vc_checkout": "git checkout 8d5cc5a8ca9324154568470b1e8be20df57bedb3",
+            "branch": "master",
+            "version": "19.04-29",
+            "source_path": "/var/lib/jenkins2/workspace/build--librtbrickinfra/DEBUG/source/bd"
+          }
+        }
+      ]
+    }
     """
 
     @classmethod
     def setOids(cls, oidDb, bdsData, bdsIds, birthday):
+        """Populates OID DB with BDS information.
+
+        Takes known objects from JSON document, puts them into
+        the OID DB as specific MIB managed objects.
+
+        Args:
+            oidDb (OidDb): OID DB instance to work on
+            bdsData (dict): BDS information to put into OID DB
+            bdsIds (list): list of last known BDS record sequence IDs
+            birthday (float): timestamp of system initialization
+
+        Raises:
+            BdsError: on OID DB population error
+        """
 
         swString = mapping_functions.stringFromSoftwareInfo(bdsData)
 

--- a/bdssnmpadaptor/mapping_modules/confd_local_system_software_info_confd.py
+++ b/bdssnmpadaptor/mapping_modules/confd_local_system_software_info_confd.py
@@ -14,19 +14,17 @@ class ConfdLocalSystemSoftwareInfoConfd(object):
     """
 
     @classmethod
-    def setOids(cls, bdsJsonResponseDict, targetOidDb,
-                tableSequenceList, birthday):
+    def setOids(cls, oidDb, bdsData, bdsIds, birthday):
 
-        swString = mapping_functions.stringFromSoftwareInfo(bdsJsonResponseDict)
+        swString = mapping_functions.stringFromSoftwareInfo(bdsData)
 
-        with targetOidDb.module(__name__) as add:
+        with oidDb.module(__name__) as add:
 
-            #add('IF-MIB', 'ifDescr', 1, value=swString)
             add('SNMPv2-MIB', 'sysDescr', 1, value=swString)
 
-            # targetOidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
+            # oidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
 
-            # for index,bdsJsonObject in enumerate(bdsJsonResponseDict['objects"]):
+            # for index,bdsJsonObject in enumerate(bdsData['objects"]):
             #     #indexString = bdsJsonObject["attribute"]["library"]
             #     #indexCharList = [str(ord(c)) for c in indexString]
             #     #index = str(len(indexCharList)) + "." + ".".join(indexCharList)  # FIXME add description

--- a/bdssnmpadaptor/mapping_modules/confd_local_system_software_info_confd.py
+++ b/bdssnmpadaptor/mapping_modules/confd_local_system_software_info_confd.py
@@ -66,8 +66,6 @@ class ConfdLocalSystemSoftwareInfoConfd(object):
 
             add('SNMPv2-MIB', 'sysDescr', 1, value=swString)
 
-            # oidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
-
             # for index,bdsJsonObject in enumerate(bdsData['objects"]):
             #     #indexString = bdsJsonObject["attribute"]["library"]
             #     #indexCharList = [str(ord(c)) for c in indexString]

--- a/bdssnmpadaptor/mapping_modules/ffwd_default_interface_logical.py
+++ b/bdssnmpadaptor/mapping_modules/ffwd_default_interface_logical.py
@@ -59,7 +59,6 @@ class FfwdDefaultInterfaceLogical(object):
         """
 
         with oidDb.module(__name__) as add:
-            # oidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
 
             for bdsJsonObject in bdsData['objects']:
                 ifName = bdsJsonObject['attribute']['interface_name']

--- a/bdssnmpadaptor/mapping_modules/ffwd_default_interface_logical.py
+++ b/bdssnmpadaptor/mapping_modules/ffwd_default_interface_logical.py
@@ -40,13 +40,12 @@ class FfwdDefaultInterfaceLogical(object):
     """
 
     @classmethod
-    def setOids(cls, bdsJsonResponseDict, targetOidDb,
-                tableSequenceList, birthday):
+    def setOids(cls, oidDb, bdsData, bdsIds, birthday):
 
-        with targetOidDb.module(__name__) as add:
-            # targetOidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
+        with oidDb.module(__name__) as add:
+            # oidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
 
-            for bdsJsonObject in bdsJsonResponseDict['objects']:
+            for bdsJsonObject in bdsData['objects']:
                 ifName = bdsJsonObject['attribute']['interface_name']
                 index = mapping_functions.ifIndexFromIfName(ifName)
 

--- a/bdssnmpadaptor/mapping_modules/ffwd_default_interface_logical.py
+++ b/bdssnmpadaptor/mapping_modules/ffwd_default_interface_logical.py
@@ -10,12 +10,17 @@ from bdssnmpadaptor import mapping_functions
 
 
 class FfwdDefaultInterfaceLogical(object):
-    """Logical interface
+    """Implement SNMP IF-MIB for logical BDS interfaces.
 
-    curl -X POST -H "Content-Type: application/json" -H "Accept: */*" -H "connection: close"\
-        -H "Accept-Encoding: application/json"\
-        -d '{"table": {"table_name": "default.interface.logical"}}'\
-        "http://10.0.3.50:5002/bds/table/walk?format=raw" | jq '.'
+    Populates SNMP managed objects of SNMP `IF-MIB` module from
+    `default.interface.logical` BDS table.
+
+    Notes
+    -----
+
+    Expected input:
+
+    .. code-block:: json
 
     {
       "objects": [
@@ -32,15 +37,26 @@ class FfwdDefaultInterfaceLogical(object):
           "update": true,
           "sequence": 1
         }
-      ],
-      "table": {
-        "table_name": "default.interface.logical"
-      }
+      ]
     }
     """
 
     @classmethod
     def setOids(cls, oidDb, bdsData, bdsIds, birthday):
+        """Populates OID DB with BDS information.
+
+        Takes known objects from JSON document, puts them into
+        the OID DB as specific MIB managed objects.
+
+        Args:
+            oidDb (OidDb): OID DB instance to work on
+            bdsData (dict): BDS information to put into OID DB
+            bdsIds (list): list of last known BDS record sequence IDs
+            birthday (float): timestamp of system initialization
+
+        Raises:
+            BdsError: on OID DB population error
+        """
 
         with oidDb.module(__name__) as add:
             # oidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids

--- a/bdssnmpadaptor/mapping_modules/fwdd_global_interface_physical_statistics.py
+++ b/bdssnmpadaptor/mapping_modules/fwdd_global_interface_physical_statistics.py
@@ -147,8 +147,6 @@ class FwddGlobalInterfacePhysicalStatistics(object):
 
         with oidDb.module(__name__) as add:
 
-            # oidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
-
             for i, bdsJsonObject in enumerate(bdsData['objects']):
                 attribute = bdsJsonObject['attribute']
 

--- a/bdssnmpadaptor/mapping_modules/fwdd_global_interface_physical_statistics.py
+++ b/bdssnmpadaptor/mapping_modules/fwdd_global_interface_physical_statistics.py
@@ -129,14 +129,13 @@ class FwddGlobalInterfacePhysicalStatistics(object):
     }
     """
     @classmethod
-    def setOids(cls, bdsJsonResponseDict, targetOidDb,
-                lastSequenceNumberList, birthday):
+    def setOids(cls, oidDb, bdsData, bdsIds, birthday):
 
-        with targetOidDb.module(__name__) as add:
+        with oidDb.module(__name__) as add:
 
-            # targetOidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
+            # oidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
 
-            for i, bdsJsonObject in enumerate(bdsJsonResponseDict['objects']):
+            for i, bdsJsonObject in enumerate(bdsData['objects']):
                 attribute = bdsJsonObject['attribute']
 
                 ifName = attribute['interface_name']

--- a/bdssnmpadaptor/mapping_modules/fwdd_global_interface_physical_statistics.py
+++ b/bdssnmpadaptor/mapping_modules/fwdd_global_interface_physical_statistics.py
@@ -12,19 +12,22 @@ from bdssnmpadaptor import mapping_functions
 
 HEX_STRING_LAMBDA = lambda x: int(x, 16)
 
-littleEndianLongLongStruct = struct.Struct('<q')
-
 LELL_LAMBDA = lambda x: int(
-    littleEndianLongLongStruct.unpack(binascii.unhexlify(x))[0])
+    struct.Struct('<q').unpack(binascii.unhexlify(x))[0])
 
 
 class FwddGlobalInterfacePhysicalStatistics(object):
-    """Physical interface statistics
+    """Implement SNMP IF-MIB for physical BDS interfaces.
 
-    curl -X POST -H "Content-Type: application/json" -H "Accept: */*" -H "connection: close"\
-        -H "Accept-Encoding: application/json"\
-        -d '{"table": {"table_name": "global.interface.physical.statistics"}}'\
-        "http://10.0.3.10:5002/bds/table/walk?format=raw" | jq '.'
+    Populates SNMP managed objects of SNMP `IF-MIB` module from
+    `global.interface.physical.statistics` BDS table.
+
+    Notes
+    -----
+
+    Expected input:
+
+    .. code-block:: json
 
     {
       "objects": [
@@ -122,14 +125,25 @@ class FwddGlobalInterfacePhysicalStatistics(object):
           "update": true,
           "sequence": 1
         }
-      ],
-      "table": {
-        "table_name": "global.interface.physical.statistics"
-      }
+      ]
     }
     """
     @classmethod
     def setOids(cls, oidDb, bdsData, bdsIds, birthday):
+        """Populates OID DB with BDS information.
+
+        Takes known objects from JSON document, puts them into
+        the OID DB as specific MIB managed objects.
+
+        Args:
+            oidDb (OidDb): OID DB instance to work on
+            bdsData (dict): BDS information to put into OID DB
+            bdsIds (list): list of last known BDS record sequence IDs
+            birthday (float): timestamp of system initialization
+
+        Raises:
+            BdsError: on OID DB population error
+        """
 
         with oidDb.module(__name__) as add:
 

--- a/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
+++ b/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
@@ -120,26 +120,24 @@ class LldpdGlobalLldpIntfStatus(object):
     """
 
     @classmethod
-    def setOids(cls, bdsJsonResponseDict, targetOidDb,
-                lastSequenceNumberList, birthday):
+    def setOids(cls, oidDb, bdsData, bdsIds, birthday):
 
-        newSequenceNumberList = [
-            obj['sequence'] for obj in bdsJsonResponseDict['objects']]
+        newBdsIds = [obj['sequence'] for obj in bdsData['objects']]
 
-        if str(newSequenceNumberList) == str(lastSequenceNumberList):
+        if newBdsIds == bdsIds:
             return
 
         currentSysTime = int((time.time() - birthday) * 100)
 
-        with targetOidDb.module(__name__) as add:
+        with oidDb.module(__name__) as add:
 
             add('IF-MIB', 'ifNumber', 0,
-                value=len(bdsJsonResponseDict['objects']))
+                value=len(bdsData['objects']))
 
-            # targetOidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
+            # oidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
 
-            for i, bdsJsonObject in enumerate(bdsJsonResponseDict['objects']):
-                thisSequenceNumber = bdsJsonObject['sequence']
+            for i, bdsJsonObject in enumerate(bdsData['objects']):
+                currentId = bdsJsonObject['sequence']
 
                 attribute = bdsJsonObject['attribute']
 
@@ -170,13 +168,13 @@ class LldpdGlobalLldpIntfStatus(object):
                 add('IF-MIB', 'ifOperStatus', index,
                     value=IFOPERSTATUSMAP[int(attribute['link_status'])])
 
-                if len(lastSequenceNumberList) == 0:  # first run
+                if len(bdsIds) == 0:  # first run
                     add('IF-MIB', 'ifLastChange', index, value=0)
 
-                elif thisSequenceNumber != lastSequenceNumberList[i]:
+                elif currentId != bdsIds[i]:
                     add('IF-MIB', 'ifLastChange', index, value=currentSysTime)
 
-                if len(lastSequenceNumberList) == 0:  # first run
+                if len(bdsIds) == 0:  # first run
                     add('IF-MIB', 'ifStackLastChange', index, value=0)
 
                     # Fixme - do we have to observe logical interfaces?

--- a/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
+++ b/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
@@ -103,8 +103,6 @@ class LldpdGlobalLldpIntfStatus(object):
             add('IF-MIB', 'ifNumber', 0,
                 value=len(bdsData['objects']))
 
-            # oidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
-
             for i, bdsJsonObject in enumerate(bdsData['objects']):
                 currentId = bdsJsonObject['sequence']
 

--- a/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
+++ b/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
@@ -22,105 +22,74 @@ IFOPERSTATUSMAP = {
     3: 3  # testing(3)   -- in some test mode
 }
 
-bigEndianFloatStruct = struct.Struct('>f')
-littleEndianShortStruct = struct.Struct('<h')
-
 IFMTU_LAMBDA = lambda x: int(
-    littleEndianShortStruct.unpack(binascii.unhexlify(x))[0])
-
+    struct.Struct('<h').unpack(binascii.unhexlify(x))[0])
 IFSPEED_LAMBDA = lambda x: int(
-    bigEndianFloatStruct.unpack(binascii.unhexlify(x))[0] / 1000 * 8)
+    struct.Struct('>f').unpack(binascii.unhexlify(x))[0] / 1000 * 8)
 
-
-# HEX_STRING_LAMBDA = lambda x : int(x,16)
-# IFMTU_LAMBDA = lambda x : int(''.join([m[2:4]+m[0:2] for m in [x[i:i+4] for i in range(0,len(x),4)]]),16)
 
 class LldpdGlobalLldpIntfStatus(object):
-    """
-        curl -X POST -H "Content-Type: application/json" -H "Accept: */*" -H "connection: close"\
-                       -H "Accept-Encoding: application/json"\
-                       -d '{"table": {"table_name": "global.lldp.intf.status"}}'\
-                       "http://10.0.3.10:2002/bds/table/walk?format=raw" | jq '.'
+    """Implement SNMP IF-MIB for LLDP BDS interfaces.
 
+    Populates SNMP managed objects of SNMP `IF-MIB` module from
+    `global.lldp.intf.status` BDS table.
+
+    Notes
+    -----
+
+    Expected input:
+
+    .. code-block:: json
+
+    {
+      "objects": [
         {
-          "objects": [
-            {
-              "attribute": {
-                "supported_breakout_modes": [
-                  "4x1G"
-                ],
-                "configured_layer2_mtu": "dc05",
-                "supported_max_layer2_mtu": "f205",
-                "supported_min_layer2_mtu": "4000",
-                "supported_auto_negotiation": "01",
-                "configured_bandwidth": "4e9502f9",
-                "default_bandwidth": "4e9502f9",
-                "supported_bandwidths": [
-                  "10.000 Gbps",
-                  "1.000 Gbps"
-                ],
-                "interface_name": "ifp-0/0/1",
-                "interface_description": "Physical interface #1 from node 0, chip 0",
-                "interface_type": "01",
-                "bandwidth": "4e9502f9",
-                "layer2_mtu": "f205",
-                "mac_address": "b86a97a59201",
-                "admin_status": "01",
-                "link_status": "01"
-              },
-              "update": true,
-              "sequence": 200197
-            },
-            {
-              "attribute": {
-                "supported_breakout_modes": [
-                  "4x1G"
-                ],
-                "configured_layer2_mtu": "dc05",
-                "supported_max_layer2_mtu": "f205",
-                "supported_min_layer2_mtu": "4000",
-                "supported_auto_negotiation": "01",
-                "configured_bandwidth": "4e9502f9",
-                "default_bandwidth": "4e9502f9",
-                "supported_bandwidths": [
-                  "10.000 Gbps",
-                  "1.000 Gbps"
-                ],
-                "interface_name": "ifp-0/0/2",
-                "interface_description": "Physical interface #2 from node 0, chip 0",
-                "interface_type": "01",
-                "bandwidth": "4e9502f9",
-                "layer2_mtu": "f205",
-                "mac_address": "b86a97a59202",
-                "admin_status": "01",
-                "link_status": "01"
-              },
-              "update": true,
-              "sequence": 200198
-            },
-
-
-        5
-        ifTableLastChange	TICKS	ReadOnly	.1.3.6.1.2.1.31.1.5
-        The value of sysUpTime at the time of the last creation or
-        deletion of an entry in the ifTable.  If the number of
-        entries has been unchanged since the last re-initialization
-        of the local network management subsystem, then this object
-        contains a zero value.
-        6
-        ifStackLastChange	TICKS	ReadOnly	.1.3.6.1.2.1.31.1.6
-        The value of sysUpTime at the time of the last change of
-        the (whole) interface stack.  A change of the interface
-        stack is defined to be any creation, deletion, or change in
-        value of any instance of ifStackStatus.  If the interface
-        stack has been unchanged since the last re-initialization of
-        the local network management subsystem, then this object
-        contains a zero value.
-
+          "attribute": {
+            "supported_breakout_modes": [
+              "4x1G"
+            ],
+            "configured_layer2_mtu": "dc05",
+            "supported_max_layer2_mtu": "f205",
+            "supported_min_layer2_mtu": "4000",
+            "supported_auto_negotiation": "01",
+            "configured_bandwidth": "4e9502f9",
+            "default_bandwidth": "4e9502f9",
+            "supported_bandwidths": [
+              "10.000 Gbps",
+              "1.000 Gbps"
+            ],
+            "interface_name": "ifp-0/0/1",
+            "interface_description": "Physical interface #1 from node 0, chip 0",
+            "interface_type": "01",
+            "bandwidth": "4e9502f9",
+            "layer2_mtu": "f205",
+            "mac_address": "b86a97a59201",
+            "admin_status": "01",
+            "link_status": "01"
+          },
+          "update": true,
+          "sequence": 200197
+        }
+      ]
+    }
     """
 
     @classmethod
     def setOids(cls, oidDb, bdsData, bdsIds, birthday):
+        """Populates OID DB with BDS information.
+
+        Takes known objects from JSON document, puts them into
+        the OID DB as specific MIB managed objects.
+
+        Args:
+            oidDb (OidDb): OID DB instance to work on
+            bdsData (dict): BDS information to put into OID DB
+            bdsIds (list): list of last known BDS record sequence IDs
+            birthday (float): timestamp of system initialization
+
+        Raises:
+            BdsError: on OID DB population error
+        """
 
         newBdsIds = [obj['sequence'] for obj in bdsData['objects']]
 

--- a/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
+++ b/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
@@ -9,10 +9,7 @@ import binascii
 import struct
 import time
 
-from pysnmp.proto.rfc1902 import Integer32
-
 from bdssnmpadaptor import mapping_functions
-from bdssnmpadaptor.oidDb import OidDbItem
 
 IFTYPEMAP = {
     1: 6  # ethernet-csmacd(6)
@@ -136,13 +133,8 @@ class LldpdGlobalLldpIntfStatus(object):
 
         with targetOidDb.module(__name__) as add:
 
-            targetOidDb.insertOid(
-                newOidItem=OidDbItem(
-                    bdsMappingFunc=__name__,
-                    oid='1.3.6.1.2.1.2.1.0',
-                    name='ifIndex',
-                    pysnmpBaseType=Integer32,
-                    value=len(bdsJsonResponseDict['objects'])))
+            add('IF-MIB', 'ifNumber', 0,
+                value=len(bdsJsonResponseDict['objects']))
 
             # targetOidDb.deleteOidsWithPrefix(oidSegment)  #delete existing TableOids
 

--- a/bdssnmpadaptor/mapping_modules/predefined_oids.py
+++ b/bdssnmpadaptor/mapping_modules/predefined_oids.py
@@ -9,6 +9,11 @@
 
 
 class StaticAndPredefinedOids(object):
+    """Implement multiple SNMP MIBs based on static configuration.
+
+    Populates some of SNMP managed objects of SNMP `HOST-RESOURCES-MIB`,
+    `SNMPv2-MIB` and `ENTITY-MIB` modules based on statically configured data.
+    """
 
     SYSTEM_TABLE_COLUMNS = [
         'sysDescr',
@@ -166,6 +171,20 @@ class StaticAndPredefinedOids(object):
 
     @classmethod
     def setOids(cls, oidDb, staticOidDict, bdsIds, birthday):
+        """Populates OID DB with BDS information.
+
+        Takes known objects from JSON document, puts them into
+        the OID DB as specific MIB managed objects.
+
+        Args:
+            oidDb (OidDb): OID DB instance to work on
+            bdsData (dict): BDS information to put into OID DB
+            bdsIds (list): list of last known BDS record sequence IDs
+            birthday (float): timestamp of system initialization
+
+        Raises:
+            BdsError: on OID DB population error
+        """
 
         with oidDb.module(__name__) as add:
 

--- a/bdssnmpadaptor/mapping_modules/predefined_oids.py
+++ b/bdssnmpadaptor/mapping_modules/predefined_oids.py
@@ -165,10 +165,9 @@ class StaticAndPredefinedOids(object):
     ]
 
     @classmethod
-    def setOids(cls, staticOidDict, targetOidDb,
-                lastSequenceNumberList, birthday):
+    def setOids(cls, oidDb, staticOidDict, bdsIds, birthday):
 
-        with targetOidDb.module(__name__) as add:
+        with oidDb.module(__name__) as add:
 
             for column in cls.SYSTEM_TABLE_COLUMNS:
                 add('SNMPv2-MIB', column, 0, value=staticOidDict[column])

--- a/bdssnmpadaptor/oidDb.py
+++ b/bdssnmpadaptor/oidDb.py
@@ -65,7 +65,7 @@ class OidDb(object):
 
     def add(self, mibName, mibSymbol, *indices, value=None,
             valueFormat=None, bdsMappingFunc=None):
-        """ Database Item, which pysnmp attributes required for get and getnext.
+        """Database Item, which pysnmp attributes required for get and getnext.
 
         Args:
             mibName (str): MIB name e.g. SNMPv2-MIB. This MIB must be in MIB search path.

--- a/tests/unit/commands/test_adaptor.py
+++ b/tests/unit/commands/test_adaptor.py
@@ -29,7 +29,6 @@ class BdsSnmpAdaptorTestCase(unittest.TestCase):
 
         mock_access_instance = mock_access.return_value
 
-        mock_access_instance.getOidDb.assert_called_once_with()
         mock_access_instance.run_forever.assert_called_once_with()
 
         mock_mibctrl.assert_called_once_with()

--- a/tests/unit/mapping_modules/test_confd_global_interface_container.py
+++ b/tests/unit/mapping_modules/test_confd_global_interface_container.py
@@ -12,7 +12,7 @@ import sys
 import unittest
 from unittest import mock
 
-from bdssnmpadaptor import oidDb
+from bdssnmpadaptor import oid_db
 from bdssnmpadaptor.mapping_modules import confd_global_interface_container
 
 
@@ -24,9 +24,9 @@ class ConfdGlobalInterfaceContainerTestCase(unittest.TestCase):
         JSON_RESPONSE = json.load(fl)
 
     def setUp(self):
-        with mock.patch.object(oidDb, 'loadConfig', autospec=True):
-            with mock.patch.object(oidDb, 'set_logging', autospec=True):
-                self.oidDb = oidDb.OidDb({'config': {}})
+        with mock.patch.object(oid_db, 'loadConfig', autospec=True):
+            with mock.patch.object(oid_db, 'set_logging', autospec=True):
+                self.oidDb = oid_db.OidDb({'config': {}})
 
         self.container = confd_global_interface_container.ConfdGlobalInterfaceContainer()
 

--- a/tests/unit/mapping_modules/test_confd_global_interface_container.py
+++ b/tests/unit/mapping_modules/test_confd_global_interface_container.py
@@ -36,7 +36,7 @@ class ConfdGlobalInterfaceContainerTestCase(unittest.TestCase):
         super(ConfdGlobalInterfaceContainerTestCase, self).setUp()
 
     def test_setOids(self):
-        self.container.setOids(self.JSON_RESPONSE, self.oidDb, [], 0)
+        self.container.setOids(self.oidDb, self.JSON_RESPONSE, [], 0)
 
         oids_in_db = []
         oid = '1.3.6'

--- a/tests/unit/mapping_modules/test_confd_global_interface_physical.py
+++ b/tests/unit/mapping_modules/test_confd_global_interface_physical.py
@@ -12,7 +12,7 @@ import sys
 import unittest
 from unittest import mock
 
-from bdssnmpadaptor import oidDb
+from bdssnmpadaptor import oid_db
 from bdssnmpadaptor.mapping_modules import confd_global_interface_physical
 
 
@@ -24,9 +24,9 @@ class ConfdGlobalInterfacePhysicalTestCase(unittest.TestCase):
         JSON_RESPONSE = json.load(fl)
 
     def setUp(self):
-        with mock.patch.object(oidDb, 'loadConfig', autospec=True):
-            with mock.patch.object(oidDb, 'set_logging', autospec=True):
-                self.oidDb = oidDb.OidDb({'config': {}})
+        with mock.patch.object(oid_db, 'loadConfig', autospec=True):
+            with mock.patch.object(oid_db, 'set_logging', autospec=True):
+                self.oidDb = oid_db.OidDb({'config': {}})
 
         self.container = confd_global_interface_physical.ConfdGlobalInterfacePhysical()
 

--- a/tests/unit/mapping_modules/test_confd_global_interface_physical.py
+++ b/tests/unit/mapping_modules/test_confd_global_interface_physical.py
@@ -36,7 +36,7 @@ class ConfdGlobalInterfacePhysicalTestCase(unittest.TestCase):
         super(ConfdGlobalInterfacePhysicalTestCase, self).setUp()
 
     def test_setOids(self):
-        self.container.setOids(self.JSON_RESPONSE, self.oidDb, [], 0)
+        self.container.setOids(self.oidDb, self.JSON_RESPONSE, [], 0)
 
         oids_in_db = []
         oid = '1.3.6'

--- a/tests/unit/mapping_modules/test_confd_global_startup_status_confd.py
+++ b/tests/unit/mapping_modules/test_confd_global_startup_status_confd.py
@@ -12,7 +12,7 @@ import sys
 import unittest
 from unittest import mock
 
-from bdssnmpadaptor import oidDb
+from bdssnmpadaptor import oid_db
 from bdssnmpadaptor.mapping_modules import confd_global_startup_status_confd
 
 
@@ -35,11 +35,11 @@ class ConfdGlobalStartupStatusConfdTestCase(unittest.TestCase):
         JSON_RESPONSE = json.load(fl)
 
     def setUp(self):
-        with mock.patch.object(oidDb, 'loadConfig', autospec=True) as config_mock:
+        with mock.patch.object(oid_db, 'loadConfig', autospec=True) as config_mock:
             config_mock.return_value = self.CONFIG['config']
 
-            with mock.patch.object(oidDb, 'set_logging', autospec=True):
-                self.oidDb = oidDb.OidDb(self.CONFIG)
+            with mock.patch.object(oid_db, 'set_logging', autospec=True):
+                self.oidDb = oid_db.OidDb(self.CONFIG)
 
         self.container = confd_global_startup_status_confd.ConfdGlobalStartupStatusConfd()
 

--- a/tests/unit/mapping_modules/test_confd_global_startup_status_confd.py
+++ b/tests/unit/mapping_modules/test_confd_global_startup_status_confd.py
@@ -49,7 +49,7 @@ class ConfdGlobalStartupStatusConfdTestCase(unittest.TestCase):
         super(ConfdGlobalStartupStatusConfdTestCase, self).setUp()
 
     def test_setOids(self):
-        self.container.setOids(self.JSON_RESPONSE, self.oidDb, [], 0)
+        self.container.setOids(self.oidDb, self.JSON_RESPONSE, [], 0)
 
         oids_in_db = []
         oid = '1.3.6'

--- a/tests/unit/mapping_modules/test_confd_local_system_software_info_confd.py
+++ b/tests/unit/mapping_modules/test_confd_local_system_software_info_confd.py
@@ -12,7 +12,7 @@ import sys
 import unittest
 from unittest import mock
 
-from bdssnmpadaptor import oidDb
+from bdssnmpadaptor import oid_db
 from bdssnmpadaptor.mapping_modules import confd_local_system_software_info_confd
 
 
@@ -24,9 +24,9 @@ class ConfdLocalSystemSoftwareInfoConfdTestCase(unittest.TestCase):
         JSON_RESPONSE = json.load(fl)
 
     def setUp(self):
-        with mock.patch.object(oidDb, 'loadConfig', autospec=True):
-            with mock.patch.object(oidDb, 'set_logging', autospec=True):
-                self.oidDb = oidDb.OidDb({'config': {}})
+        with mock.patch.object(oid_db, 'loadConfig', autospec=True):
+            with mock.patch.object(oid_db, 'set_logging', autospec=True):
+                self.oidDb = oid_db.OidDb({'config': {}})
 
         self.container = confd_local_system_software_info_confd.ConfdLocalSystemSoftwareInfoConfd()
 

--- a/tests/unit/mapping_modules/test_confd_local_system_software_info_confd.py
+++ b/tests/unit/mapping_modules/test_confd_local_system_software_info_confd.py
@@ -36,7 +36,7 @@ class ConfdLocalSystemSoftwareInfoConfdTestCase(unittest.TestCase):
         super(ConfdLocalSystemSoftwareInfoConfdTestCase, self).setUp()
 
     def test_setOids(self):
-        self.container.setOids(self.JSON_RESPONSE, self.oidDb, [], 0)
+        self.container.setOids(self.oidDb, self.JSON_RESPONSE, [], 0)
 
         oids_in_db = []
         oid = '1.3.6'

--- a/tests/unit/mapping_modules/test_ffwd_default_interface_logical.py
+++ b/tests/unit/mapping_modules/test_ffwd_default_interface_logical.py
@@ -12,7 +12,7 @@ import sys
 import unittest
 from unittest import mock
 
-from bdssnmpadaptor import oidDb
+from bdssnmpadaptor import oid_db
 from bdssnmpadaptor.mapping_modules import ffwd_default_interface_logical
 
 
@@ -24,9 +24,9 @@ class FfwdDefaultInterfaceLogicalTestCase(unittest.TestCase):
         JSON_RESPONSE = json.load(fl)
 
     def setUp(self):
-        with mock.patch.object(oidDb, 'loadConfig', autospec=True):
-            with mock.patch.object(oidDb, 'set_logging', autospec=True):
-                self.oidDb = oidDb.OidDb({'config': {}})
+        with mock.patch.object(oid_db, 'loadConfig', autospec=True):
+            with mock.patch.object(oid_db, 'set_logging', autospec=True):
+                self.oidDb = oid_db.OidDb({'config': {}})
 
         self.container = ffwd_default_interface_logical.FfwdDefaultInterfaceLogical()
 

--- a/tests/unit/mapping_modules/test_ffwd_default_interface_logical.py
+++ b/tests/unit/mapping_modules/test_ffwd_default_interface_logical.py
@@ -36,7 +36,7 @@ class FfwdDefaultInterfaceLogicalTestCase(unittest.TestCase):
         super(FfwdDefaultInterfaceLogicalTestCase, self).setUp()
 
     def test_setOids(self):
-        self.container.setOids(self.JSON_RESPONSE, self.oidDb, [], 0)
+        self.container.setOids(self.oidDb, self.JSON_RESPONSE, [], 0)
 
         oids_in_db = []
         oid = '1.3.6'

--- a/tests/unit/mapping_modules/test_fwdd_global_interface_physical_statistics.py
+++ b/tests/unit/mapping_modules/test_fwdd_global_interface_physical_statistics.py
@@ -36,7 +36,7 @@ class FwddGlobalInterfacePhysicalStatisticsTestCase(unittest.TestCase):
         super(FwddGlobalInterfacePhysicalStatisticsTestCase, self).setUp()
 
     def test_setOids(self):
-        self.container.setOids(self.JSON_RESPONSE, self.oidDb, [], 0)
+        self.container.setOids(self.oidDb, self.JSON_RESPONSE, [], 0)
 
         oids_in_db = []
         oid = '1.3.6'

--- a/tests/unit/mapping_modules/test_fwdd_global_interface_physical_statistics.py
+++ b/tests/unit/mapping_modules/test_fwdd_global_interface_physical_statistics.py
@@ -12,7 +12,7 @@ import sys
 import unittest
 from unittest import mock
 
-from bdssnmpadaptor import oidDb
+from bdssnmpadaptor import oid_db
 from bdssnmpadaptor.mapping_modules import fwdd_global_interface_physical_statistics
 
 
@@ -24,9 +24,9 @@ class FwddGlobalInterfacePhysicalStatisticsTestCase(unittest.TestCase):
         JSON_RESPONSE = json.load(fl)
 
     def setUp(self):
-        with mock.patch.object(oidDb, 'loadConfig', autospec=True):
-            with mock.patch.object(oidDb, 'set_logging', autospec=True):
-                self.oidDb = oidDb.OidDb({'config': {}})
+        with mock.patch.object(oid_db, 'loadConfig', autospec=True):
+            with mock.patch.object(oid_db, 'set_logging', autospec=True):
+                self.oidDb = oid_db.OidDb({'config': {}})
 
         self.container = fwdd_global_interface_physical_statistics.FwddGlobalInterfacePhysicalStatistics()
 

--- a/tests/unit/mapping_modules/test_lldpd_global_lldp_intf_status.py
+++ b/tests/unit/mapping_modules/test_lldpd_global_lldp_intf_status.py
@@ -36,7 +36,7 @@ class LldpdGlobalLldpIntfStatusTestCase(unittest.TestCase):
         super(LldpdGlobalLldpIntfStatusTestCase, self).setUp()
 
     def test_setOids(self):
-        self.container.setOids(self.JSON_RESPONSE, self.oidDb, [], 0)
+        self.container.setOids(self.oidDb, self.JSON_RESPONSE, [], 0)
 
         oids_in_db = []
         oid = '1.3.6'

--- a/tests/unit/mapping_modules/test_lldpd_global_lldp_intf_status.py
+++ b/tests/unit/mapping_modules/test_lldpd_global_lldp_intf_status.py
@@ -12,7 +12,7 @@ import sys
 import unittest
 from unittest import mock
 
-from bdssnmpadaptor import oidDb
+from bdssnmpadaptor import oid_db
 from bdssnmpadaptor.mapping_modules import lldpd_global_lldp_intf_status
 
 
@@ -24,9 +24,9 @@ class LldpdGlobalLldpIntfStatusTestCase(unittest.TestCase):
         JSON_RESPONSE = json.load(fl)
 
     def setUp(self):
-        with mock.patch.object(oidDb, 'loadConfig', autospec=True):
-            with mock.patch.object(oidDb, 'set_logging', autospec=True):
-                self.oidDb = oidDb.OidDb({'config': {}})
+        with mock.patch.object(oid_db, 'loadConfig', autospec=True):
+            with mock.patch.object(oid_db, 'set_logging', autospec=True):
+                self.oidDb = oid_db.OidDb({'config': {}})
 
         self.container = lldpd_global_lldp_intf_status.LldpdGlobalLldpIntfStatus()
 

--- a/tests/unit/mapping_modules/test_predefined_oids.py
+++ b/tests/unit/mapping_modules/test_predefined_oids.py
@@ -11,7 +11,7 @@ import sys
 import unittest
 from unittest import mock
 
-from bdssnmpadaptor import oidDb
+from bdssnmpadaptor import oid_db
 from bdssnmpadaptor.mapping_modules import predefined_oids
 
 
@@ -37,10 +37,10 @@ class StaticAndPredefinedOidsTestCase(unittest.TestCase):
     }
 
     def setUp(self):
-        with mock.patch.object(oidDb, 'loadConfig', autospec=True) as config_mock:
-            with mock.patch.object(oidDb, 'set_logging', autospec=True):
+        with mock.patch.object(oid_db, 'loadConfig', autospec=True) as config_mock:
+            with mock.patch.object(oid_db, 'set_logging', autospec=True):
                 config_mock.return_value = self.CONFIG
-                self.oidDb = oidDb.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb({'config': {}})
 
         self.container = predefined_oids.StaticAndPredefinedOids()
 

--- a/tests/unit/mapping_modules/test_predefined_oids.py
+++ b/tests/unit/mapping_modules/test_predefined_oids.py
@@ -50,7 +50,7 @@ class StaticAndPredefinedOidsTestCase(unittest.TestCase):
         super(StaticAndPredefinedOidsTestCase, self).setUp()
 
     def test_setOids(self):
-        self.container.setOids(self.STATIC_CONFIG, self.oidDb, [], 0)
+        self.container.setOids(self.oidDb, self.STATIC_CONFIG, [], 0)
 
         oids_in_db = []
         oid = '1.3.6'

--- a/tests/unit/test_access.py
+++ b/tests/unit/test_access.py
@@ -97,17 +97,17 @@ bdsSnmpAdapter:
         mock_phy = access.REQUEST_MAPPING_DICTS[
             'confd_global_interface_physical']['mappingFunc']
         mock_phy.setOids.assert_called_once_with(
-            self.JSON_RESPONSE, mock.ANY, mock.ANY, mock.ANY)
+            mock.ANY, self.JSON_RESPONSE, mock.ANY, mock.ANY)
 
         mock_startup = access.REQUEST_MAPPING_DICTS[
             'confd_global_startup_status_confd']['mappingFunc']
         mock_startup.setOids.assert_called_once_with(
-            self.JSON_RESPONSE, mock.ANY, mock.ANY, mock.ANY)
+            mock.ANY, self.JSON_RESPONSE, mock.ANY, mock.ANY)
 
         mock_sw = access.REQUEST_MAPPING_DICTS[
             'confd_local.system.software.info.confd']['mappingFunc']
         mock_sw.setOids.assert_called_once_with(
-            self.JSON_RESPONSE, mock.ANY, mock.ANY, mock.ANY)
+            mock.ANY, self.JSON_RESPONSE, mock.ANY, mock.ANY)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/unit/test_access.py
+++ b/tests/unit/test_access.py
@@ -58,7 +58,7 @@ bdsSnmpAdapter:
         super(BdsAccessTestCase, self).setUp()
 
     def test_getOidDb(self):
-        self.assertIsInstance(self.access.getOidDb(), oidDb.OidDb)
+        self.assertIsInstance(self.access.oidDb, oidDb.OidDb)
 
     @asynctest.patch(
         'bdssnmpadaptor.access.aiohttp.ClientSession', autospec=True)

--- a/tests/unit/test_access.py
+++ b/tests/unit/test_access.py
@@ -14,7 +14,7 @@ from unittest import mock
 import asynctest
 
 from bdssnmpadaptor import access
-from bdssnmpadaptor import oidDb
+from bdssnmpadaptor import oid_db
 
 
 @mock.patch('tempfile.NamedTemporaryFile', new=mock.MagicMock)
@@ -58,7 +58,7 @@ bdsSnmpAdapter:
         super(BdsAccessTestCase, self).setUp()
 
     def test_getOidDb(self):
-        self.assertIsInstance(self.access.oidDb, oidDb.OidDb)
+        self.assertIsInstance(self.access.oidDb, oid_db.OidDb)
 
     @asynctest.patch(
         'bdssnmpadaptor.access.aiohttp.ClientSession', autospec=True)

--- a/tests/unit/test_oiddb.py
+++ b/tests/unit/test_oiddb.py
@@ -21,15 +21,12 @@ class OidDbItemTestCase(unittest.TestCase):
             bdsMappingFunc='interface_container',
             oid='1.3.6.7.8',
             name='ifIndex',
-            pysnmpBaseType=rfc1902.OctetString,
-            pysnmpRepresentation='hexValue',
-            value='123456789',
+            value=rfc1902.OctetString(hexValue='123456789'),
         )
 
         self.assertEqual('interface_container', oid.bdsMappingFunc)
         self.assertEqual(rfc1902.ObjectIdentifier('1.3.6.7.8'), oid.oid)
         self.assertEqual('ifIndex', oid.name)
-        self.assertEqual(rfc1902.OctetString, oid.pysnmpBaseType)
         self.assertEqual(b'\x124Vx\x90', oid.value)
 
     def test___lt__(self):
@@ -51,8 +48,7 @@ class OidDbItemTestCase(unittest.TestCase):
             bdsMappingFunc='interface_container',
             oid='1.3.6.7.8',
             name='ifIndex',
-            pysnmpBaseType=rfc1902.OctetString,
-            value='0x123456789',
+            value=rfc1902.OctetString(hexValue='123456789'),
         )
 
         self.assertIsInstance(str(oid), str)

--- a/tests/unit/test_oiddb.py
+++ b/tests/unit/test_oiddb.py
@@ -11,13 +11,13 @@ from unittest import mock
 
 from pysnmp.proto import rfc1902
 
-from bdssnmpadaptor import oidDb
+from bdssnmpadaptor import oid_db
 
 
 class OidDbItemTestCase(unittest.TestCase):
 
     def test___init__(self):
-        oid = oidDb.OidDbItem(
+        oid = oid_db.OidDbItem(
             bdsMappingFunc='interface_container',
             oid='1.3.6.7.8',
             name='ifIndex',
@@ -30,21 +30,21 @@ class OidDbItemTestCase(unittest.TestCase):
         self.assertEqual(b'\x124Vx\x90', oid.value)
 
     def test___lt__(self):
-        oid1 = oidDb.OidDbItem(oid='1.3.6.7.8')
-        oid2 = oidDb.OidDbItem(oid='1.3.6.8.1')
+        oid1 = oid_db.OidDbItem(oid='1.3.6.7.8')
+        oid2 = oid_db.OidDbItem(oid='1.3.6.8.1')
 
         self.assertLess(oid1, oid2)
         self.assertGreater(oid2, oid1)
 
     def test___eq__(self):
-        oid1 = oidDb.OidDbItem(oid='1.3.6.7.8')
-        oid2 = oidDb.OidDbItem(oid='1.3.6.8.1')
+        oid1 = oid_db.OidDbItem(oid='1.3.6.7.8')
+        oid2 = oid_db.OidDbItem(oid='1.3.6.8.1')
 
         self.assertNotEqual(oid1, oid2)
         self.assertEqual(oid1, oid1)
 
     def test___str__(self):
-        oid = oidDb.OidDbItem(
+        oid = oid_db.OidDbItem(
             bdsMappingFunc='interface_container',
             oid='1.3.6.7.8',
             name='ifIndex',
@@ -70,9 +70,9 @@ class OidDbTestCase(unittest.TestCase):
     ]
 
     def setUp(self):
-        with mock.patch.object(oidDb, 'loadConfig', autospec=True):
-            with mock.patch.object(oidDb, 'set_logging', autospec=True):
-                self.oidDb = oidDb.OidDb({'config': {}})
+        with mock.patch.object(oid_db, 'loadConfig', autospec=True):
+            with mock.patch.object(oid_db, 'set_logging', autospec=True):
+                self.oidDb = oid_db.OidDb({'config': {}})
 
                 for ident, value in reversed(self.MIB_OBJECTS):
                     self.oidDb.add(*ident, value=value, bdsMappingFunc=__class__)
@@ -136,9 +136,9 @@ class OidDbTestCase(unittest.TestCase):
 
         oid = rfc1902.ObjectIdentifier('1.3.6.1.2.1.1.6.0')
 
-        self.assertIn(oid, self.oidDb.oidDict)
-        self.assertEqual(b'DC', self.oidDb.oidDict[oid].value)
-        self.assertEqual('interfaces', self.oidDb.oidDict[oid].bdsMappingFunc)
+        self.assertIn(oid, self.oidDb._oids)
+        self.assertEqual(b'DC', self.oidDb._oids[oid].value)
+        self.assertEqual('interfaces', self.oidDb._oids[oid].bdsMappingFunc)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])


### PR DESCRIPTION
Add OID DB expiration feature
    
This change introduces time-based expiration of the OID DB entries. If an entry is not updated for some time (60 sec), it will be removed from the OID DB.
    
The goal is to remove BDS data that has been exposed through SNMP at some point, but then disappeared in BDS.