### PR TITLE
09 - Simplify config args passing

### DIFF
--- a/bdssnmpadaptor/access.py
+++ b/bdssnmpadaptor/access.py
@@ -65,9 +65,9 @@ class BdsAccess(object):
     in the in-memory OID DB.
     """
 
-    def __init__(self, cliArgsDict):
+    def __init__(self, args):
 
-        configDict = loadConfig(cliArgsDict['config'])
+        configDict = loadConfig(args.config)
 
         self.moduleLogger = set_logging(configDict, __class__.__name__)
 
@@ -79,7 +79,7 @@ class BdsAccess(object):
 
         self.staticOidDict = configDict['responder']['staticOidContent']
 
-        self._oidDb = OidDb(cliArgsDict)
+        self._oidDb = OidDb(args)
 
         # keeps track of changes to the BDS data
         self._bdsIds = collections.defaultdict(list)

--- a/bdssnmpadaptor/commands/adaptor.py
+++ b/bdssnmpadaptor/commands/adaptor.py
@@ -55,30 +55,28 @@ See https://www.rtbrick.com for RtBrick product information.
         '--pidfile', type=str,
         help='Path to a PID file the process would create')
 
-    cliargs = parser.parse_args()
+    args = parser.parse_args()
 
-    cliArgsDict = vars(cliargs)
+    args.config = os.path.abspath(args.config)
 
-    cliargs.config = os.path.abspath(cliargs.config)
-
-    if cliargs.daemonize:
+    if args.daemonize:
         daemon.daemonize()
 
-    if cliargs.pidfile:
-        daemon.pidfile(cliargs.pidfile)
+    if args.pidfile:
+        daemon.pidfile(args.pidfile)
 
-    bdsAccess = BdsAccess(cliArgsDict)
+    bdsAccess = BdsAccess(args)
 
     mibController = MibInstrumController()
-    mibController.setOidDbAndLogger(bdsAccess.oidDb, cliArgsDict)
+    mibController.setOidDbAndLogger(bdsAccess.oidDb, args)
 
-    SnmpCommandResponder(cliArgsDict, mibController)
+    SnmpCommandResponder(args, mibController)
 
     queue = asyncio.Queue()
 
-    snmpNtfOrg = SnmpNotificationOriginator(cliArgsDict, queue)
+    snmpNtfOrg = SnmpNotificationOriginator(args, queue)
 
-    httpServer = AsyncioRestServer(cliArgsDict, queue)
+    httpServer = AsyncioRestServer(args, queue)
 
     loop = asyncio.get_event_loop()
 

--- a/bdssnmpadaptor/mib_controller.py
+++ b/bdssnmpadaptor/mib_controller.py
@@ -46,12 +46,12 @@ class MibInstrumController(instrum.AbstractMibInstrumController):
 
         return _oidDbItem.oid, _oidDbItem.value
 
-    def setOidDbAndLogger(self, _oidDb, cliArgsDict):
-        self._oidDb = _oidDb
+    def setOidDbAndLogger(self, oidDb, args):
+        self._oidDb = oidDb
 
         self.moduleFileNameWithoutPy, _ = os.path.splitext(os.path.basename(__file__))
 
-        configDict = loadConfig(cliArgsDict['config'])
+        configDict = loadConfig(args.config)
 
         self.moduleLogger = set_logging(configDict, __class__.__name__)
 

--- a/bdssnmpadaptor/oid_db.py
+++ b/bdssnmpadaptor/oid_db.py
@@ -49,8 +49,8 @@ class OidDb(object):
      """
     EXPIRE_PERIOD = 60
 
-    def __init__(self, cliArgsDict):
-        configDict = loadConfig(cliArgsDict['config'])
+    def __init__(self, args):
+        configDict = loadConfig(args.config)
 
         self.moduleLogger = set_logging(configDict, __class__.__name__)
 

--- a/bdssnmpadaptor/rest_server.py
+++ b/bdssnmpadaptor/rest_server.py
@@ -21,11 +21,11 @@ class AsyncioRestServer(object):
     notification through REST API. Places received notifications
     into a queue for consumers to read from.
     """
-    def __init__(self, cliArgsDict, queue):
+    def __init__(self, args, queue):
 
         self.moduleFileNameWithoutPy, _ = os.path.splitext(os.path.basename(__file__))
 
-        configDict = loadConfig(cliArgsDict['config'])
+        configDict = loadConfig(args.config)
 
         self.moduleLogger = set_logging(configDict, __class__.__name__)
 

--- a/bdssnmpadaptor/snmp_notificator.py
+++ b/bdssnmpadaptor/snmp_notificator.py
@@ -36,8 +36,8 @@ class SnmpNotificationOriginator(object):
 
     TARGETS_TAG = 'mgrs'
 
-    def __init__(self, cliArgsDict, queue):
-        configDict = loadConfig(cliArgsDict['config'])
+    def __init__(self, args, queue):
+        configDict = loadConfig(args.config)
 
         self.moduleLogger = set_logging(configDict, __class__.__name__)
 

--- a/bdssnmpadaptor/snmp_responder.py
+++ b/bdssnmpadaptor/snmp_responder.py
@@ -23,10 +23,10 @@ class SnmpCommandResponder(object):
     management information and responds back to SNMP manager.
     """
 
-    def __init__(self, cliArgsDict, mibController):
+    def __init__(self, args, mibController):
         self.mibController = mibController
 
-        configDict = loadConfig(cliArgsDict['config'])
+        configDict = loadConfig(args.config)
 
         self.moduleLogger = set_logging(configDict, __class__.__name__)
 
@@ -45,8 +45,6 @@ class SnmpCommandResponder(object):
         self.moduleLogger.info(
             f'Running SNMP engine ID {self.snmpEngine.snmpEngineID.prettyPrint()}, '
             f'boots {engineBoots}')
-
-        cliArgsDict['snmpEngineIdValue'] = self.snmpEngine.snmpEngineID.asOctets()
 
         # UDP over IPv4
         try:

--- a/tests/unit/mapping_modules/test_confd_global_interface_container.py
+++ b/tests/unit/mapping_modules/test_confd_global_interface_container.py
@@ -26,7 +26,7 @@ class ConfdGlobalInterfaceContainerTestCase(unittest.TestCase):
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True):
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         self.container = confd_global_interface_container.ConfdGlobalInterfaceContainer()
 

--- a/tests/unit/mapping_modules/test_confd_global_interface_physical.py
+++ b/tests/unit/mapping_modules/test_confd_global_interface_physical.py
@@ -26,7 +26,7 @@ class ConfdGlobalInterfacePhysicalTestCase(unittest.TestCase):
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True):
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         self.container = confd_global_interface_physical.ConfdGlobalInterfacePhysical()
 

--- a/tests/unit/mapping_modules/test_confd_global_startup_status_confd.py
+++ b/tests/unit/mapping_modules/test_confd_global_startup_status_confd.py
@@ -20,13 +20,11 @@ from bdssnmpadaptor.mapping_modules import confd_global_startup_status_confd
 class ConfdGlobalStartupStatusConfdTestCase(unittest.TestCase):
 
     CONFIG = {
-        'config': {
-            'snmp': {
-                'mibs': [
-                    'mibs',
-                    '/usr/share/snmp/mibs'
-                ]
-            }
+        'snmp': {
+            'mibs': [
+                'mibs',
+                '/usr/share/snmp/mibs'
+            ]
         }
     }
 
@@ -36,10 +34,10 @@ class ConfdGlobalStartupStatusConfdTestCase(unittest.TestCase):
 
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True) as config_mock:
-            config_mock.return_value = self.CONFIG['config']
+            config_mock.return_value = self.CONFIG
 
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb(self.CONFIG)
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config=self.CONFIG))
 
         self.container = confd_global_startup_status_confd.ConfdGlobalStartupStatusConfd()
 

--- a/tests/unit/mapping_modules/test_confd_local_system_software_info_confd.py
+++ b/tests/unit/mapping_modules/test_confd_local_system_software_info_confd.py
@@ -26,7 +26,7 @@ class ConfdLocalSystemSoftwareInfoConfdTestCase(unittest.TestCase):
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True):
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         self.container = confd_local_system_software_info_confd.ConfdLocalSystemSoftwareInfoConfd()
 

--- a/tests/unit/mapping_modules/test_ffwd_default_interface_logical.py
+++ b/tests/unit/mapping_modules/test_ffwd_default_interface_logical.py
@@ -26,7 +26,7 @@ class FfwdDefaultInterfaceLogicalTestCase(unittest.TestCase):
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True):
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         self.container = ffwd_default_interface_logical.FfwdDefaultInterfaceLogical()
 

--- a/tests/unit/mapping_modules/test_fwdd_global_interface_physical_statistics.py
+++ b/tests/unit/mapping_modules/test_fwdd_global_interface_physical_statistics.py
@@ -26,7 +26,7 @@ class FwddGlobalInterfacePhysicalStatisticsTestCase(unittest.TestCase):
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True):
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         self.container = fwdd_global_interface_physical_statistics.FwddGlobalInterfacePhysicalStatistics()
 

--- a/tests/unit/mapping_modules/test_lldpd_global_lldp_intf_status.py
+++ b/tests/unit/mapping_modules/test_lldpd_global_lldp_intf_status.py
@@ -26,7 +26,7 @@ class LldpdGlobalLldpIntfStatusTestCase(unittest.TestCase):
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True):
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         self.container = lldpd_global_lldp_intf_status.LldpdGlobalLldpIntfStatus()
 

--- a/tests/unit/mapping_modules/test_predefined_oids.py
+++ b/tests/unit/mapping_modules/test_predefined_oids.py
@@ -40,7 +40,7 @@ class StaticAndPredefinedOidsTestCase(unittest.TestCase):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True) as config_mock:
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
                 config_mock.return_value = self.CONFIG
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         self.container = predefined_oids.StaticAndPredefinedOids()
 

--- a/tests/unit/test_access.py
+++ b/tests/unit/test_access.py
@@ -53,7 +53,7 @@ bdsSnmpAdapter:
                 side_effect=[io.StringIO(self.CONFIG),
                              io.StringIO(self.CONFIG),
                              io.StringIO(self.CONFIG)]):
-            self.access = access.BdsAccess({'config': '/file'})
+            self.access = access.BdsAccess(mock.MagicMock(config={}))
 
         super(BdsAccessTestCase, self).setUp()
 

--- a/tests/unit/test_mib_controller.py
+++ b/tests/unit/test_mib_controller.py
@@ -41,7 +41,7 @@ class MibControllerTestCase(unittest.TestCase):
                              io.StringIO(self.CONFIG),
                              io.StringIO(self.CONFIG)]):
             self.mc = mib_controller.MibInstrumController().setOidDbAndLogger(
-                self.mock_oidDb, {'config': '/file'})
+                self.mock_oidDb, mock.MagicMock(config={}))
 
         super(MibControllerTestCase, self).setUp()
 

--- a/tests/unit/test_oiddb.py
+++ b/tests/unit/test_oiddb.py
@@ -72,7 +72,7 @@ class OidDbTestCase(unittest.TestCase):
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True):
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
                 for ident, value in reversed(self.MIB_OBJECTS):
                     self.oidDb.add(*ident, value=value, bdsMappingFunc=__class__)
@@ -82,7 +82,7 @@ class OidDbTestCase(unittest.TestCase):
     @mock.patch.object(oid_db, 'loadConfig', autospec=True)
     @mock.patch.object(oid_db, 'set_logging', autospec=True)
     def test_add(self, mock_set_logging, mock_loadConfig):
-        oidDb = oid_db.OidDb({'config': {}})
+        oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         oidDb.add('SNMPv2-MIB', 'sysDescr', 0, value='my system',
                   bdsMappingFunc=__class__)
@@ -103,7 +103,7 @@ class OidDbTestCase(unittest.TestCase):
     def test_add_expire(self, mock_set_logging, mock_loadConfig, mock_time):
         mock_time.return_value = 0
 
-        oidDb = oid_db.OidDb({'config': {}})
+        oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         # add sysDescr and expect it to be in the OID DB
 

--- a/tests/unit/test_rest_server.py
+++ b/tests/unit/test_rest_server.py
@@ -44,7 +44,8 @@ bdsSnmpAdapter:
                              io.StringIO(self.CONFIG),
                              io.StringIO(self.CONFIG)]):
             mock_queue = mock.MagicMock()
-            rs = rest_server.AsyncioRestServer({'config': '/file'}, mock_queue)
+            rs = rest_server.AsyncioRestServer(
+                mock.MagicMock(config={}), mock_queue)
 
             self.assertEqual('0.0.0.0', rs.listeningIP)
             self.assertEqual(5000, rs.listeningPort)
@@ -59,7 +60,8 @@ bdsSnmpAdapter:
                     side_effect=[io.StringIO(self.CONFIG),
                                  io.StringIO(self.CONFIG),
                                  io.StringIO(self.CONFIG)]):
-                rs = rest_server.AsyncioRestServer({'config': '/file'}, mock_queue)
+                rs = rest_server.AsyncioRestServer(
+                    mock.MagicMock(config={}), mock_queue)
 
             mock_web.json_response = asynctest.CoroutineMock()
 
@@ -85,7 +87,8 @@ bdsSnmpAdapter:
                     side_effect=[io.StringIO(self.CONFIG),
                                  io.StringIO(self.CONFIG),
                                  io.StringIO(self.CONFIG)]):
-                rs = rest_server.AsyncioRestServer({'config': '/file'}, mock_queue)
+                rs = rest_server.AsyncioRestServer(
+                    mock.MagicMock(config={}), mock_queue)
 
             mock_runner = mock_web.ServerRunner.return_value
             mock_runner.setup = asynctest.CoroutineMock()

--- a/tests/unit/test_snmp_notificator.py
+++ b/tests/unit/test_snmp_notificator.py
@@ -82,7 +82,7 @@ bdsSnmpAdapter:
                              io.StringIO(self.CONFIG),
                              io.StringIO(self.CONFIG)]):
             snmp_notificator.SnmpNotificationOriginator(
-                {'config': '/file'}, self.mock_queue)
+                mock.MagicMock(config={}), self.mock_queue)
 
         mock_snmpEngine = mock_snmp_config.getSnmpEngine.return_value
 
@@ -138,7 +138,7 @@ bdsSnmpAdapter:
                              io.StringIO(self.CONFIG),
                              io.StringIO(self.CONFIG)]):
             ntf = snmp_notificator.SnmpNotificationOriginator(
-                {'config': '/file'}, self.mock_queue)
+                mock.MagicMock(config={}), self.mock_queue)
 
         self.my_loop.run_until_complete(ntf.sendTrap({}))
 

--- a/tests/unit/test_snmp_responder.py
+++ b/tests/unit/test_snmp_responder.py
@@ -59,7 +59,8 @@ bdsSnmpAdapter:
                              io.StringIO(self.CONFIG),
                              io.StringIO(self.CONFIG)]):
             mock_oiddb = mock.MagicMock()
-            snmp_responder.SnmpCommandResponder({'config': '/file'}, mock_oiddb)
+            snmp_responder.SnmpCommandResponder(
+                mock.MagicMock(config={}), mock_oiddb)
 
         mock_snmpEngine = mock_snmp_config.getSnmpEngine.return_value
 


### PR DESCRIPTION
This is a trivial change making use of argparse object for handing over config information instead of dealing with a dict. Using argparse object seems more reliable and less wordy.
