### PR TITLE
11 -  Attach Python snippets to predefined MIB objects

### DIFF
--- a/bdssnmpadaptor/access.py
+++ b/bdssnmpadaptor/access.py
@@ -159,17 +159,16 @@ class BdsAccess(object):
         from BDS REST API and pushing it into OID DB.
         """
 
+        try:
+            StaticAndPredefinedOids.setOids(
+                self._oidDb, self._staticOidDict, [], 0)
+
+        except Exception as exc:
+            self._moduleLogger.error(
+                f'failed at populating OID DB with predefined OIDs: {exc}')
+
         while True:
             await asyncio.sleep(self.POLL_PERIOD)
-
-            try:
-                StaticAndPredefinedOids.setOids(
-                    self._oidDb, self._staticOidDict, [], 0)
-
-            except Exception as exc:
-                self._moduleLogger.error(
-                    f'failed at populating OID DB with predefined OIDs: {exc}')
-                continue
 
             for bdsReqKey in REQUEST_MAPPING_DICTS:
                 self._moduleLogger.debug(f'working on {bdsReqKey}')

--- a/bdssnmpadaptor/access.py
+++ b/bdssnmpadaptor/access.py
@@ -65,9 +65,9 @@ class BdsAccess(object):
     in the in-memory OID DB.
     """
 
-    def __init__(self, cliArgsDict):
+    def __init__(self, args):
 
-        configDict = loadConfig(cliArgsDict['config'])
+        configDict = loadConfig(args.config)
 
         self.moduleLogger = set_logging(configDict, __class__.__name__)
 
@@ -79,7 +79,7 @@ class BdsAccess(object):
 
         self.staticOidDict = configDict['responder']['staticOidContent']
 
-        self._oidDb = OidDb(cliArgsDict)
+        self._oidDb = OidDb(args)
 
         # keeps track of changes to the BDS data
         self._bdsIds = collections.defaultdict(list)

--- a/bdssnmpadaptor/access.py
+++ b/bdssnmpadaptor/access.py
@@ -65,19 +65,19 @@ class BdsAccess(object):
     in the in-memory OID DB.
     """
 
+    POLL_PERIOD = 5
+
     def __init__(self, args):
 
         configDict = loadConfig(args.config)
 
-        self.moduleLogger = set_logging(configDict, __class__.__name__)
+        self._moduleLogger = set_logging(configDict, __class__.__name__)
 
-        self.moduleLogger.debug(f'configDict:{configDict}')
-        self.rtbrickHost = configDict['access']['rtbrickHost']
-        self.rtbrickPorts = (configDict['access']['rtbrickPorts'])
-        # self.rtbrickCtrldPort = configDict['access']['rtbrickCtrldPort']
-        # self.rtbrickContainerName = configDict['access']['rtbrickContainerName']
+        self._moduleLogger.debug(f'configDict:{configDict}')
+        self._restHost = configDict['access']['rtbrickHost']
+        self._restPorts = (configDict['access']['rtbrickPorts'])
 
-        self.staticOidDict = configDict['responder']['staticOidContent']
+        self._staticOidDict = configDict['responder']['staticOidContent']
 
         self._oidDb = OidDb(args)
 
@@ -89,26 +89,34 @@ class BdsAccess(object):
 
     @property
     def oidDb(self):
+        """Return OID DB instance"""
         return self._oidDb
 
-    async def getJson(self, bdsRequest):
-        bdsProcess = bdsRequest['process']
-        bdsSuffix = bdsRequest['urlSuffix']
-        bdsTable = bdsRequest['table']
+    async def fetchTable(self, tableInfo):
+        """Fetch BDS table from REST API within asyncio loop.
 
-        if 'attributes' in bdsRequest:
-            attributeDict = {}
+        Args:
+            tableInfo (dict): table information to read
 
-            for attribute in bdsRequest['attributes']:
-                attributeDict[attribute] = bdsRequest['attributes'][attribute]
+        Returns:
+            tuple: (status, responseData) where `status` being `True`
+                indicates success, `False` indicates failure.
+                BDS table contents is returned in the response `dict`.
+        """
+        process = tableInfo['process']
+        suffix = tableInfo['urlSuffix']
+        table = tableInfo['table']
+
+        if 'attributes' in tableInfo:
+            attributes = tableInfo['attributes']
 
             requestData = {
                 'table': {
-                    'table_name': bdsTable
+                    'table_name': table
                 },
                 'objects': [
                     {
-                        'attribute': attributeDict
+                        'attribute': attributes
                     }
                 ]
             }
@@ -116,81 +124,80 @@ class BdsAccess(object):
         else:
             requestData = {
                 'table': {
-                    'table_name': bdsTable
+                    'table_name': table
                 }
             }
 
-        rtbrickProcessPortDict = [
-            x for x in self.rtbrickPorts if list(x)[0] == bdsProcess][0]
+        ports = [int(x[process]) for x in self._restPorts
+                 if process in x]
 
-        rtbrickPort = int(rtbrickProcessPortDict[bdsProcess])
-
-        url = f'http://{self.rtbrickHost}:{rtbrickPort}/{bdsSuffix}'
+        url = f'http://{self._restHost}:{ports[0]}/{suffix}'
 
         try:
-            headers = {
-                'Content-Type': 'application/json'
-            }
-
             async with aiohttp.ClientSession() as session:
-                async with session.post(url, timeout=5,
-                                        headers=headers,
-                                        json=requestData) as response:
-                    bdsResponse = await response.json(content_type='application/json')
+                async with session.post(
+                        url, timeout=5, json=requestData) as response:
+                    responseData = await response.json()
 
         except Exception as exc:
-            self.moduleLogger.error(f'HTTP request for {url} failed: {exc}')
+            self._moduleLogger.error(f'HTTP request for {url} failed: {exc}')
             return False, exc
 
         if response.status != 200:
-            self.moduleLogger.error(f'received {response.status} for {url}')
+            self._moduleLogger.error(f'received {response.status} for {url}')
             return False, 'status != 200'
 
-        self.moduleLogger.info(f'received HTTP {response.status} for {url}')
-        self.moduleLogger.debug(f'HTTP response {response}')
+        self._moduleLogger.info(f'received HTTP {response.status} for {url}')
+        self._moduleLogger.debug(f'HTTP response {responseData}')
 
-        return True, bdsResponse
+        return True, responseData
 
-    async def run_forever(self):
+    async def periodicRetriever(self):
+        """Periodically fetch BDS information.
+
+        Loops infinitely over asyncio coroutines fetching BDS information
+        from BDS REST API and pushing it into OID DB.
+        """
 
         while True:
-            await asyncio.sleep(5)
+            await asyncio.sleep(self.POLL_PERIOD)
 
             try:
                 StaticAndPredefinedOids.setOids(
-                    self._oidDb, self.staticOidDict, [], 0)
+                    self._oidDb, self._staticOidDict, [], 0)
 
             except Exception as exc:
-                self.moduleLogger.error(
+                self._moduleLogger.error(
                     f'failed at populating OID DB with predefined OIDs: {exc}')
                 continue
 
             for bdsReqKey in REQUEST_MAPPING_DICTS:
-                self.moduleLogger.debug(f'working on {bdsReqKey}')
+                self._moduleLogger.debug(f'working on {bdsReqKey}')
 
                 bdsRequest = REQUEST_MAPPING_DICTS[bdsReqKey]['bdsRequest']
-                mappingfunc = REQUEST_MAPPING_DICTS[bdsReqKey]['mappingFunc']
 
-                resultFlag, bdsResponse = await self.getJson(bdsRequest)
+                resultFlag, bdsResponse = await self.fetchTable(bdsRequest)
 
                 if not resultFlag:
-                    self.moduleLogger.error('BDS JSON is not available')
+                    self._moduleLogger.error('BDS information is not available')
                     continue
 
                 tableKey = f'{bdsRequest["process"]}_{bdsRequest["table"]}'
 
-                self.moduleLogger.debug(
+                self._moduleLogger.debug(
                     f'bdsResponses[{tableKey}] {bdsResponse}')
 
                 bdsId = self._bdsIds[bdsReqKey]
+
+                mappingfunc = REQUEST_MAPPING_DICTS[bdsReqKey]['mappingFunc']
 
                 try:
                     mappingfunc.setOids(
                         self._oidDb, bdsResponse, bdsId, BIRTHDAY)
 
                 except Exception as exc:
-                    self.moduleLogger.error(
+                    self._moduleLogger.error(
                         f'failed at populating OID DB from BDS response: {exc}')
                     continue
 
-            self.moduleLogger.debug(f'done refreshing OID DB')
+            self._moduleLogger.debug(f'done refreshing OID DB')

--- a/bdssnmpadaptor/commands/adaptor.py
+++ b/bdssnmpadaptor/commands/adaptor.py
@@ -55,30 +55,28 @@ See https://www.rtbrick.com for RtBrick product information.
         '--pidfile', type=str,
         help='Path to a PID file the process would create')
 
-    cliargs = parser.parse_args()
+    args = parser.parse_args()
 
-    cliArgsDict = vars(cliargs)
+    args.config = os.path.abspath(args.config)
 
-    cliargs.config = os.path.abspath(cliargs.config)
-
-    if cliargs.daemonize:
+    if args.daemonize:
         daemon.daemonize()
 
-    if cliargs.pidfile:
-        daemon.pidfile(cliargs.pidfile)
+    if args.pidfile:
+        daemon.pidfile(args.pidfile)
 
-    bdsAccess = BdsAccess(cliArgsDict)
+    bdsAccess = BdsAccess(args)
 
     mibController = MibInstrumController()
-    mibController.setOidDbAndLogger(bdsAccess.oidDb, cliArgsDict)
+    mibController.setOidDbAndLogger(bdsAccess.oidDb, args)
 
-    SnmpCommandResponder(cliArgsDict, mibController)
+    SnmpCommandResponder(args, mibController)
 
     queue = asyncio.Queue()
 
-    snmpNtfOrg = SnmpNotificationOriginator(cliArgsDict, queue)
+    snmpNtfOrg = SnmpNotificationOriginator(args, queue)
 
-    httpServer = AsyncioRestServer(cliArgsDict, queue)
+    httpServer = AsyncioRestServer(args, queue)
 
     loop = asyncio.get_event_loop()
 

--- a/bdssnmpadaptor/commands/adaptor.py
+++ b/bdssnmpadaptor/commands/adaptor.py
@@ -82,7 +82,7 @@ See https://www.rtbrick.com for RtBrick product information.
 
     try:
         loop.run_until_complete(
-            asyncio.gather(bdsAccess.run_forever(),
+            asyncio.gather(bdsAccess.periodicRetriever(),
                            snmpNtfOrg.run_forever(), httpServer.initialize())
         )
 

--- a/bdssnmpadaptor/mapping_modules/predefined_oids.py
+++ b/bdssnmpadaptor/mapping_modules/predefined_oids.py
@@ -15,16 +15,6 @@ class StaticAndPredefinedOids(object):
     `SNMPv2-MIB` and `ENTITY-MIB` modules based on statically configured data.
     """
 
-    SYSTEM_TABLE_COLUMNS = [
-        'sysDescr',
-        'sysObjectID',
-        'sysUpTime',
-        'sysContact',
-        'sysName',
-        'sysLocation',
-        'sysServices'
-    ]
-
     ENT_TABLE_COLUMNS = [
         'entPhysicalIndex',
         'entPhysicalDescr',
@@ -188,14 +178,21 @@ class StaticAndPredefinedOids(object):
 
         with oidDb.module(__name__) as add:
 
-            for column in cls.SYSTEM_TABLE_COLUMNS:
-                add('SNMPv2-MIB', column, 0, value=staticOidDict[column])
+            for objectName, objectInfo in staticOidDict.items():
+                mibName, mibSymbol = objectName.split('::', 1)
 
-            add('HOST-RESOURCES-MIB', 'hrSystemUptime', 0, value=0)
+                code = None
+
+                if 'code' in objectInfo:
+                    code = compile(objectInfo['code'], '<%s>' % objectName, 'exec')
+
+                value = objectInfo.get('value')
+
+                add(mibName, mibSymbol, 0, value=value, code=code)
 
         for i, phyValueList in enumerate(cls.ENT_PHYSICAL_TABLE):
 
             row = cls.ENT_PHYSICAL_TABLE[i]
 
-            for j, column in enumerate(cls.ENT_TABLE_COLUMNS):
-                add('ENTITY-MIB', column, row[0], value=row[j])
+            for j, scalar in enumerate(cls.ENT_TABLE_COLUMNS):
+                add('ENTITY-MIB', scalar, row[0], value=row[j])

--- a/bdssnmpadaptor/mib_controller.py
+++ b/bdssnmpadaptor/mib_controller.py
@@ -46,12 +46,12 @@ class MibInstrumController(instrum.AbstractMibInstrumController):
 
         return _oidDbItem.oid, _oidDbItem.value
 
-    def setOidDbAndLogger(self, _oidDb, cliArgsDict):
-        self._oidDb = _oidDb
+    def setOidDbAndLogger(self, oidDb, args):
+        self._oidDb = oidDb
 
         self.moduleFileNameWithoutPy, _ = os.path.splitext(os.path.basename(__file__))
 
-        configDict = loadConfig(cliArgsDict['config'])
+        configDict = loadConfig(args.config)
 
         self.moduleLogger = set_logging(configDict, __class__.__name__)
 

--- a/bdssnmpadaptor/oid_db.py
+++ b/bdssnmpadaptor/oid_db.py
@@ -49,8 +49,8 @@ class OidDb(object):
      """
     EXPIRE_PERIOD = 60
 
-    def __init__(self, cliArgsDict):
-        configDict = loadConfig(cliArgsDict['config'])
+    def __init__(self, args):
+        configDict = loadConfig(args.config)
 
         self.moduleLogger = set_logging(configDict, __class__.__name__)
 

--- a/bdssnmpadaptor/oid_db.py
+++ b/bdssnmpadaptor/oid_db.py
@@ -73,7 +73,7 @@ class OidDb(object):
         self._dirty = True  # DB needs sorting
 
     def add(self, mibName, mibSymbol, *indices, value=None,
-            valueFormat=None, bdsMappingFunc=None):
+            valueFormat=None, code=None, bdsMappingFunc=None):
         """Database Item, which pysnmp attributes required for get and getnext.
 
         Args:
@@ -82,6 +82,7 @@ class OidDb(object):
             indices (vararg): one or more objects representing indices. Should be `0` for scalars.
             value: put this value into MIB managed object. This is what SNMP manager will get in response.
             valueFormat (string): 'hexValue' to indiciate hex `value` initializer
+            code (object): use this Python code object for getting a value at run time
             bdsMappingFunc(string): used to mark, which mapping function owns this oid. (used for delete)
 
         Examples:
@@ -95,16 +96,16 @@ class OidDb(object):
 
         objectIdentity, objectSyntax = obj.resolveWithMib(self._mibViewController)
 
-        representation = {valueFormat if valueFormat else 'value': value}
-
         try:
+            representation = {valueFormat if valueFormat else 'value': value}
             objectSyntax = objectSyntax.clone(**representation)
 
             oidDbItem = OidDbItem(
                 bdsMappingFunc=bdsMappingFunc,
                 oid=objectIdentity.getOid(),
                 name=objectIdentity.getMibSymbol()[1],
-                value=objectSyntax
+                value=objectSyntax,
+                code=code
             )
 
         except Exception as exc:
@@ -115,7 +116,7 @@ class OidDb(object):
 
         self.moduleLogger.debug(
             f'{"updating" if oidDbItem.oid in self._oids else "adding"} '
-            f'{oidDbItem.oid} {oidDbItem.value}')
+            f'{oidDbItem.oid} {"<code>" if code else oidDbItem.value}')
 
         self._oids[oidDbItem.oid] = oidDbItem
 
@@ -202,7 +203,7 @@ class OidDbItem(object):
     Implements managed objects comparison what is used for ordering
     objects by OID.
     """
-    def __init__(self, bdsMappingFunc=None, oid=None, name=None, value=None):
+    def __init__(self, bdsMappingFunc=None, oid=None, name=None, value=None, code=None):
         """Database Item, which pysnmp attributes required for get and getnext.
 
         Args:
@@ -210,6 +211,7 @@ class OidDbItem(object):
             oid(string): oid as string, separated by dots.
             name(string): name of the oid, should map with MIB identifier name, although this is not enforced
             value: object that holds the value of the OID. Type is flexible, subject to OID type
+            code (object): use this Python code object for getting a value at run time
 
         Examples:
           OidDbItem(
@@ -222,6 +224,7 @@ class OidDbItem(object):
         self.oid = ObjectIdentifier(oid)
         self.name = name
         self.value = value
+        self.code = code
 
     def __lt__(self, oidItem):
         return self.oid < oidItem.oid
@@ -230,4 +233,4 @@ class OidDbItem(object):
         return self.oid == oidItem.oid
 
     def __str__(self):
-        return "{self.name}({self.value}):{self.value}"
+        return "{self.name}({self.value}):{self.value}{self.code}"

--- a/bdssnmpadaptor/rest_server.py
+++ b/bdssnmpadaptor/rest_server.py
@@ -21,11 +21,11 @@ class AsyncioRestServer(object):
     notification through REST API. Places received notifications
     into a queue for consumers to read from.
     """
-    def __init__(self, cliArgsDict, queue):
+    def __init__(self, args, queue):
 
         self.moduleFileNameWithoutPy, _ = os.path.splitext(os.path.basename(__file__))
 
-        configDict = loadConfig(cliArgsDict['config'])
+        configDict = loadConfig(args.config)
 
         self.moduleLogger = set_logging(configDict, __class__.__name__)
 

--- a/bdssnmpadaptor/snmp_notificator.py
+++ b/bdssnmpadaptor/snmp_notificator.py
@@ -36,8 +36,8 @@ class SnmpNotificationOriginator(object):
 
     TARGETS_TAG = 'mgrs'
 
-    def __init__(self, cliArgsDict, queue):
-        configDict = loadConfig(cliArgsDict['config'])
+    def __init__(self, args, queue):
+        configDict = loadConfig(args.config)
 
         self.moduleLogger = set_logging(configDict, __class__.__name__)
 

--- a/bdssnmpadaptor/snmp_responder.py
+++ b/bdssnmpadaptor/snmp_responder.py
@@ -23,10 +23,10 @@ class SnmpCommandResponder(object):
     management information and responds back to SNMP manager.
     """
 
-    def __init__(self, cliArgsDict, mibController):
+    def __init__(self, args, mibController):
         self.mibController = mibController
 
-        configDict = loadConfig(cliArgsDict['config'])
+        configDict = loadConfig(args.config)
 
         self.moduleLogger = set_logging(configDict, __class__.__name__)
 
@@ -45,8 +45,6 @@ class SnmpCommandResponder(object):
         self.moduleLogger.info(
             f'Running SNMP engine ID {self.snmpEngine.snmpEngineID.prettyPrint()}, '
             f'boots {engineBoots}')
-
-        cliArgsDict['snmpEngineIdValue'] = self.snmpEngine.snmpEngineID.asOctets()
 
         # UDP over IPv4
         try:

--- a/conf/bds-snmp-adaptor.yml
+++ b/conf/bds-snmp-adaptor.yml
@@ -47,14 +47,53 @@ bdsSnmpAdapter:
     listeningIP: 0.0.0.0  # SNMP command responder listens on this address
     listeningPort: 161  # SNMP command responder listens on this port
     staticOidContent:
-      sysDescr: l2.pod2.nbg2.rtbrick.net
-      sysContact: stefan@rtbrick.com
-      sysName: l2.pod2.nbg2.rtbrick.net
-      sysLocation: nbg2.rtbrick.net
+      SNMPv2-MIB::sysDescr:
+        value:
+          l2.pod2.nbg2.rtbrick.net
+
+      SNMPv2-MIB::sysContact:
+        value:
+          stefan@rtbrick.com
+
+      SNMPv2-MIB::sysName:
+        value:
+          l2.pod2.nbg2.rtbrick.net
+
+      SNMPv2-MIB::sysLocation:
+        value:
+          nbg2.rtbrick.net
+
       # FIXME get from BDS entity table
-      sysObjectID: '1.3.6.1.4.1.50058.102.1'
-      sysUpTime: 0
-      sysServices: 72
+      SNMPv2-MIB::sysObjectID:
+        value:
+          1.3.6.1.4.1.50058.102.1
+
+      SNMPv2-MIB::sysUpTime:
+        value:
+          0
+        code: |+
+          import time
+
+          BIRTHDAY = time.time()
+
+          def value(*args, **kwargs):
+            return int((time.time() - BIRTHDAY) * 100)
+
+      SNMPv2-MIB::sysServices:
+        value:
+          72
+
+      HOST-RESOURCES-MIB::hrSystemUptime:
+        value:
+          0
+        code: |+
+          import time
+
+          BIRTHDAY = time.time()
+
+          def value(*args, **kwargs):
+            return int((time.time() - BIRTHDAY) * 100)
+
   # SNMP notification originator configuration
   notificator:
     # temp config lines to test incomming graylog message end #

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -97,14 +97,53 @@ BDS REST API client and REST API server.
         listeningIP: 0.0.0.0  # SNMP command responder listens on this address
         listeningPort: 161  # SNMP command responder listens on this port
         staticOidContent:
-          sysDescr: l2.pod2.nbg2.rtbrick.net
-          sysContact: stefan@rtbrick.com
-          sysName: l2.pod2.nbg2.rtbrick.net
-          sysLocation: nbg2.rtbrick.net
+          SNMPv2-MIB::sysDescr:
+            value:
+              l2.pod2.nbg2.rtbrick.net
+
+          SNMPv2-MIB::sysContact:
+            value:
+              stefan@rtbrick.com
+
+          SNMPv2-MIB::sysName:
+            value:
+              l2.pod2.nbg2.rtbrick.net
+
+          SNMPv2-MIB::sysLocation:
+            value:
+              nbg2.rtbrick.net
+
           # FIXME get from BDS entity table
-          sysObjectID: '1.3.6.1.4.1.50058.102.1'
-          sysUpTime: 0
-          sysServices: 72
+          SNMPv2-MIB::sysObjectID:
+            value:
+              1.3.6.1.4.1.50058.102.1
+
+          SNMPv2-MIB::sysUpTime:
+            value:
+              0
+            code: |+
+              import time
+
+              BIRTHDAY = time.time()
+
+              def value(*args, **kwargs):
+                return int((time.time() - BIRTHDAY) * 100)
+
+          SNMPv2-MIB::sysServices:
+            value:
+              72
+
+          HOST-RESOURCES-MIB::hrSystemUptime:
+            value:
+              0
+            code: |+
+              import time
+
+              BIRTHDAY = time.time()
+
+              def value(*args, **kwargs):
+                return int((time.time() - BIRTHDAY) * 100)
+
       # SNMP notification originator configuration
       notificator:
         # temp config lines to test incomming graylog message end #

--- a/tests/unit/commands/test_adaptor.py
+++ b/tests/unit/commands/test_adaptor.py
@@ -29,7 +29,7 @@ class BdsSnmpAdaptorTestCase(unittest.TestCase):
 
         mock_access_instance = mock_access.return_value
 
-        mock_access_instance.run_forever.assert_called_once_with()
+        mock_access_instance.periodicRetriever.assert_called_once_with()
 
         mock_mibctrl.assert_called_once_with()
 

--- a/tests/unit/mapping_modules/test_confd_global_interface_container.py
+++ b/tests/unit/mapping_modules/test_confd_global_interface_container.py
@@ -26,7 +26,7 @@ class ConfdGlobalInterfaceContainerTestCase(unittest.TestCase):
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True):
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         self.container = confd_global_interface_container.ConfdGlobalInterfaceContainer()
 

--- a/tests/unit/mapping_modules/test_confd_global_interface_physical.py
+++ b/tests/unit/mapping_modules/test_confd_global_interface_physical.py
@@ -26,7 +26,7 @@ class ConfdGlobalInterfacePhysicalTestCase(unittest.TestCase):
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True):
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         self.container = confd_global_interface_physical.ConfdGlobalInterfacePhysical()
 

--- a/tests/unit/mapping_modules/test_confd_global_startup_status_confd.py
+++ b/tests/unit/mapping_modules/test_confd_global_startup_status_confd.py
@@ -20,13 +20,11 @@ from bdssnmpadaptor.mapping_modules import confd_global_startup_status_confd
 class ConfdGlobalStartupStatusConfdTestCase(unittest.TestCase):
 
     CONFIG = {
-        'config': {
-            'snmp': {
-                'mibs': [
-                    'mibs',
-                    '/usr/share/snmp/mibs'
-                ]
-            }
+        'snmp': {
+            'mibs': [
+                'mibs',
+                '/usr/share/snmp/mibs'
+            ]
         }
     }
 
@@ -36,10 +34,10 @@ class ConfdGlobalStartupStatusConfdTestCase(unittest.TestCase):
 
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True) as config_mock:
-            config_mock.return_value = self.CONFIG['config']
+            config_mock.return_value = self.CONFIG
 
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb(self.CONFIG)
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config=self.CONFIG))
 
         self.container = confd_global_startup_status_confd.ConfdGlobalStartupStatusConfd()
 

--- a/tests/unit/mapping_modules/test_confd_local_system_software_info_confd.py
+++ b/tests/unit/mapping_modules/test_confd_local_system_software_info_confd.py
@@ -26,7 +26,7 @@ class ConfdLocalSystemSoftwareInfoConfdTestCase(unittest.TestCase):
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True):
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         self.container = confd_local_system_software_info_confd.ConfdLocalSystemSoftwareInfoConfd()
 

--- a/tests/unit/mapping_modules/test_ffwd_default_interface_logical.py
+++ b/tests/unit/mapping_modules/test_ffwd_default_interface_logical.py
@@ -26,7 +26,7 @@ class FfwdDefaultInterfaceLogicalTestCase(unittest.TestCase):
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True):
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         self.container = ffwd_default_interface_logical.FfwdDefaultInterfaceLogical()
 

--- a/tests/unit/mapping_modules/test_fwdd_global_interface_physical_statistics.py
+++ b/tests/unit/mapping_modules/test_fwdd_global_interface_physical_statistics.py
@@ -26,7 +26,7 @@ class FwddGlobalInterfacePhysicalStatisticsTestCase(unittest.TestCase):
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True):
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         self.container = fwdd_global_interface_physical_statistics.FwddGlobalInterfacePhysicalStatistics()
 

--- a/tests/unit/mapping_modules/test_lldpd_global_lldp_intf_status.py
+++ b/tests/unit/mapping_modules/test_lldpd_global_lldp_intf_status.py
@@ -26,7 +26,7 @@ class LldpdGlobalLldpIntfStatusTestCase(unittest.TestCase):
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True):
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         self.container = lldpd_global_lldp_intf_status.LldpdGlobalLldpIntfStatus()
 

--- a/tests/unit/mapping_modules/test_predefined_oids.py
+++ b/tests/unit/mapping_modules/test_predefined_oids.py
@@ -40,7 +40,7 @@ class StaticAndPredefinedOidsTestCase(unittest.TestCase):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True) as config_mock:
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
                 config_mock.return_value = self.CONFIG
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         self.container = predefined_oids.StaticAndPredefinedOids()
 

--- a/tests/unit/mapping_modules/test_predefined_oids.py
+++ b/tests/unit/mapping_modules/test_predefined_oids.py
@@ -19,13 +19,27 @@ from bdssnmpadaptor.mapping_modules import predefined_oids
 class StaticAndPredefinedOidsTestCase(unittest.TestCase):
 
     STATIC_CONFIG = {
-        'sysDescr': 'l2.pod2.nbg2.rtbrick.net',
-        'sysContact': 'stefan@rtbrick.com',
-        'sysName': 'l2.pod2.nbg2.rtbrick.net',
-        'sysLocation': 'nbg2.rtbrick.net',
-        'sysObjectID': '1.3.6.1.4.1.50058.102.1',
-        'sysUpTime': 0,
-        'sysServices': 72
+        'SNMPv2-MIB::sysDescr': {
+            'value': 'l2.pod2.nbg2.rtbrick.net'
+        },
+        'SNMPv2-MIB::sysContact': {
+            'value':'stefan@rtbrick.com'
+        },
+        'SNMPv2-MIB::sysName': {
+            'value': 'l2.pod2.nbg2.rtbrick.net'
+        },
+        'SNMPv2-MIB::sysLocation': {
+            'value': 'nbg2.rtbrick.net'
+        },
+        'SNMPv2-MIB::sysObjectID': {
+            'value': '1.3.6.1.4.1.50058.102.1'
+        },
+        'SNMPv2-MIB::sysUpTime': {
+            'value': 0
+        },
+        'SNMPv2-MIB::sysServices': {
+            'value': 72
+        }
     }
 
     CONFIG = {
@@ -67,7 +81,6 @@ class StaticAndPredefinedOidsTestCase(unittest.TestCase):
             '1.3.6.1.2.1.1.5.0',
             '1.3.6.1.2.1.1.6.0',
             '1.3.6.1.2.1.1.7.0',
-            '1.3.6.1.2.1.25.1.1.0',
             '1.3.6.1.2.1.47.1.1.1.1.1.1',
             '1.3.6.1.2.1.47.1.1.1.1.1.2',
             '1.3.6.1.2.1.47.1.1.1.1.1.3',

--- a/tests/unit/test_access.py
+++ b/tests/unit/test_access.py
@@ -86,7 +86,7 @@ bdsSnmpAdapter:
         with asynctest.patch('asyncio.sleep') as sleep:
             sleep.side_effect = [lambda: 1, asyncio.CancelledError]
             try:
-                self.my_loop.run_until_complete(self.access.run_forever())
+                self.my_loop.run_until_complete(self.access.periodicRetriever())
 
             except asyncio.CancelledError:
                 pass

--- a/tests/unit/test_access.py
+++ b/tests/unit/test_access.py
@@ -53,7 +53,7 @@ bdsSnmpAdapter:
                 side_effect=[io.StringIO(self.CONFIG),
                              io.StringIO(self.CONFIG),
                              io.StringIO(self.CONFIG)]):
-            self.access = access.BdsAccess({'config': '/file'})
+            self.access = access.BdsAccess(mock.MagicMock(config={}))
 
         super(BdsAccessTestCase, self).setUp()
 

--- a/tests/unit/test_mib_controller.py
+++ b/tests/unit/test_mib_controller.py
@@ -26,10 +26,21 @@ class MibControllerTestCase(unittest.TestCase):
          - fwdd-hald: 5002  # fwwd REST API listens on this port"
       responder:
         staticOidContent:
-          sysDescr: l2.pod2.nbg2.rtbrick.net
-          sysContact: stefan@rtbrick.com
-          sysName: l2.pod2.nbg2.rtbrick.net
-          sysLocation: nbg2.rtbrick.net
+          SNMPv2-MIB::sysDescr:
+            value:
+              l2.pod2.nbg2.rtbrick.net
+
+          SNMPv2-MIB::sysContact:
+            value:
+              stefan@rtbrick.com
+    
+          SNMPv2-MIB::sysName:
+            value:
+              l2.pod2.nbg2.rtbrick.net
+    
+          SNMPv2-MIB::sysLocation:
+            value:
+              nbg2.rtbrick.net
     """
 
     def setUp(self):
@@ -49,8 +60,7 @@ class MibControllerTestCase(unittest.TestCase):
         varBinds = [('1.3.6.1.2.1.1.0', 123)]
 
         mock_oidItem = self.mock_oidDb.getObjFromOid.return_value
-        mock_oidItem.pysnmpBaseType = lambda **kw: kw['key']
-        mock_oidItem.pysnmpRepresentation = 'key'
+        mock_oidItem.code = None
 
         rspVarBinds = self.mc.readVars(varBinds)
 
@@ -67,8 +77,7 @@ class MibControllerTestCase(unittest.TestCase):
 
         mock_getNextOid = self.mock_oidDb.getNextOid.return_value
         mock_oidItem = self.mock_oidDb.getObjFromOid.return_value
-        mock_oidItem.pysnmpBaseType = lambda **kw: kw['key']
-        mock_oidItem.pysnmpRepresentation = 'key'
+        mock_oidItem.code = None
 
         rspVarBinds = self.mc.readNextVars(varBinds)
 

--- a/tests/unit/test_mib_controller.py
+++ b/tests/unit/test_mib_controller.py
@@ -41,7 +41,7 @@ class MibControllerTestCase(unittest.TestCase):
                              io.StringIO(self.CONFIG),
                              io.StringIO(self.CONFIG)]):
             self.mc = mib_controller.MibInstrumController().setOidDbAndLogger(
-                self.mock_oidDb, {'config': '/file'})
+                self.mock_oidDb, mock.MagicMock(config={}))
 
         super(MibControllerTestCase, self).setUp()
 

--- a/tests/unit/test_oiddb.py
+++ b/tests/unit/test_oiddb.py
@@ -72,7 +72,7 @@ class OidDbTestCase(unittest.TestCase):
     def setUp(self):
         with mock.patch.object(oid_db, 'loadConfig', autospec=True):
             with mock.patch.object(oid_db, 'set_logging', autospec=True):
-                self.oidDb = oid_db.OidDb({'config': {}})
+                self.oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
                 for ident, value in reversed(self.MIB_OBJECTS):
                     self.oidDb.add(*ident, value=value, bdsMappingFunc=__class__)
@@ -82,7 +82,7 @@ class OidDbTestCase(unittest.TestCase):
     @mock.patch.object(oid_db, 'loadConfig', autospec=True)
     @mock.patch.object(oid_db, 'set_logging', autospec=True)
     def test_add(self, mock_set_logging, mock_loadConfig):
-        oidDb = oid_db.OidDb({'config': {}})
+        oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         oidDb.add('SNMPv2-MIB', 'sysDescr', 0, value='my system',
                   bdsMappingFunc=__class__)
@@ -103,7 +103,7 @@ class OidDbTestCase(unittest.TestCase):
     def test_add_expire(self, mock_set_logging, mock_loadConfig, mock_time):
         mock_time.return_value = 0
 
-        oidDb = oid_db.OidDb({'config': {}})
+        oidDb = oid_db.OidDb(mock.MagicMock(config={}))
 
         # add sysDescr and expect it to be in the OID DB
 

--- a/tests/unit/test_rest_server.py
+++ b/tests/unit/test_rest_server.py
@@ -44,7 +44,8 @@ bdsSnmpAdapter:
                              io.StringIO(self.CONFIG),
                              io.StringIO(self.CONFIG)]):
             mock_queue = mock.MagicMock()
-            rs = rest_server.AsyncioRestServer({'config': '/file'}, mock_queue)
+            rs = rest_server.AsyncioRestServer(
+                mock.MagicMock(config={}), mock_queue)
 
             self.assertEqual('0.0.0.0', rs.listeningIP)
             self.assertEqual(5000, rs.listeningPort)
@@ -59,7 +60,8 @@ bdsSnmpAdapter:
                     side_effect=[io.StringIO(self.CONFIG),
                                  io.StringIO(self.CONFIG),
                                  io.StringIO(self.CONFIG)]):
-                rs = rest_server.AsyncioRestServer({'config': '/file'}, mock_queue)
+                rs = rest_server.AsyncioRestServer(
+                    mock.MagicMock(config={}), mock_queue)
 
             mock_web.json_response = asynctest.CoroutineMock()
 
@@ -85,7 +87,8 @@ bdsSnmpAdapter:
                     side_effect=[io.StringIO(self.CONFIG),
                                  io.StringIO(self.CONFIG),
                                  io.StringIO(self.CONFIG)]):
-                rs = rest_server.AsyncioRestServer({'config': '/file'}, mock_queue)
+                rs = rest_server.AsyncioRestServer(
+                    mock.MagicMock(config={}), mock_queue)
 
             mock_runner = mock_web.ServerRunner.return_value
             mock_runner.setup = asynctest.CoroutineMock()

--- a/tests/unit/test_snmp_notificator.py
+++ b/tests/unit/test_snmp_notificator.py
@@ -82,7 +82,7 @@ bdsSnmpAdapter:
                              io.StringIO(self.CONFIG),
                              io.StringIO(self.CONFIG)]):
             snmp_notificator.SnmpNotificationOriginator(
-                {'config': '/file'}, self.mock_queue)
+                mock.MagicMock(config={}), self.mock_queue)
 
         mock_snmpEngine = mock_snmp_config.getSnmpEngine.return_value
 
@@ -138,7 +138,7 @@ bdsSnmpAdapter:
                              io.StringIO(self.CONFIG),
                              io.StringIO(self.CONFIG)]):
             ntf = snmp_notificator.SnmpNotificationOriginator(
-                {'config': '/file'}, self.mock_queue)
+                mock.MagicMock(config={}), self.mock_queue)
 
         self.my_loop.run_until_complete(ntf.sendTrap({}))
 

--- a/tests/unit/test_snmp_responder.py
+++ b/tests/unit/test_snmp_responder.py
@@ -59,7 +59,8 @@ bdsSnmpAdapter:
                              io.StringIO(self.CONFIG),
                              io.StringIO(self.CONFIG)]):
             mock_oiddb = mock.MagicMock()
-            snmp_responder.SnmpCommandResponder({'config': '/file'}, mock_oiddb)
+            snmp_responder.SnmpCommandResponder(
+                mock.MagicMock(config={}), mock_oiddb)
 
         mock_snmpEngine = mock_snmp_config.getSnmpEngine.return_value
 


### PR DESCRIPTION
This change moves hardcode for some of the MIB objects from the implementation to configuration. Python code snippets can be added to configuration file in form of .yaml literal blocks. The implementation will compile and execute each snippet on SNMP access.

The main use-case is to return time-bound values:

```yaml
    staticOidContent:
      SNMPv2-MIB::sysDescr:
        value:
          l2.pod2.nbg2.rtbrick.net

      SNMPv2-MIB::sysUpTime:
        value:
          0
        code: |+
          import time

          BIRTHDAY = time.time()

          def value(*args, **kwargs):
            return int((time.time() - BIRTHDAY) * 100)
```
