### PR TITLE
02 -  Fix predefined OIDs to never expire

### DIFF
--- a/bdssnmpadaptor/mapping_modules/predefined_oids.py
+++ b/bdssnmpadaptor/mapping_modules/predefined_oids.py
@@ -176,7 +176,7 @@ class StaticAndPredefinedOids(object):
             BdsError: on OID DB population error
         """
 
-        with oidDb.module(__name__) as add:
+        with oidDb.module(__name__, permanent=True) as add:
 
             for objectName, objectInfo in staticOidDict.items():
                 mibName, mibSymbol = objectName.split('::', 1)
@@ -189,4 +189,4 @@ class StaticAndPredefinedOids(object):
             row = cls.ENT_PHYSICAL_TABLE[i]
 
             for j, scalar in enumerate(cls.ENT_TABLE_COLUMNS):
-                add('ENTITY-MIB', scalar, row[0], value=row[j])
+                add('ENTITY-MIB', scalar, row[0], value=row[j], permanent=True)

--- a/bdssnmpadaptor/oid_db.py
+++ b/bdssnmpadaptor/oid_db.py
@@ -129,7 +129,7 @@ class OidDb(object):
 
         self.moduleLogger.debug(
             f'{"updating" if oidDbItem.oid in self._oids else "adding"} '
-            f'{oidDbItem.oid} {"<code>" if code else oidDbItem.value}')
+            f'{oidDbItem.oid} {"<code>" if code else oidDbItem.value.prettyPrint()}')
 
         self._oids[oidDbItem.oid] = oidDbItem
 

--- a/systemd/ubuntu/bds-snmp-adaptor.service
+++ b/systemd/ubuntu/bds-snmp-adaptor.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=RtBrick SNMP Adaptor
+Description=RtBrick BDS SNMP Adaptor
 After=network.target auditd.service
 
 [Service]

--- a/sysvinit/generic/bds-snmp-adaptor
+++ b/sysvinit/generic/bds-snmp-adaptor
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 NAME=bds-snmp-adaptor
-DESC="RtBrick SNMP Adaptor"
+DESC="RtBrick BDS SNMP Adaptor"
 PIDFILE=/run/bds-snmp-adaptor.pid
 SCRIPTNAME=/etc/init.d/$NAME
 

--- a/sysvinit/onl/bds-snmp-adaptor
+++ b/sysvinit/onl/bds-snmp-adaptor
@@ -6,13 +6,13 @@
 # X-Stop-After:      sendsigs
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: RtBrick SNMP Adaptor
-# Description:       RtBrick SNMP Adaptor
+# Short-Description: RtBrick BDS SNMP Adaptor
+# Description:       RtBrick BDS SNMP Adaptor
 ### END INIT INFO
 
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
-DESC="BDS SNMP Notification Originator"
+DESC="RtBrick BDS SNMP Adaptor"
 NAME=bds-snmp-adaptor
 
 DAEMON=/usr/local/bin/bds-snmp-adaptor

--- a/tests/unit/test_oiddb.py
+++ b/tests/unit/test_oiddb.py
@@ -175,6 +175,64 @@ pass
 
         self.assertEqual(expected, oidItem.oid)
 
+    @mock.patch('time.time', autospec=True)
+    @mock.patch.object(oid_db, 'loadConfig', autospec=True)
+    @mock.patch.object(oid_db, 'set_logging', autospec=True)
+    def test_add_permanent(self, mock_set_logging, mock_loadConfig, mock_time):
+        mock_time.return_value = 0
+
+        oidDb = oid_db.OidDb(mock.MagicMock(config={}))
+
+        # add sysDescr and expect it to be in the OID DB
+
+        oidDb.add('SNMPv2-MIB', 'sysDescr', 0, value='my system',
+                  bdsMappingFunc=__class__, permanent=True)
+
+        expected = rfc1902.ObjectIdentifier('1.3.6.1.2.1.1.1.0')
+
+        oidItem = oidDb.getObjFromOid(expected)
+
+        self.assertEqual(expected, oidItem.oid)
+
+        mock_time.return_value = 61
+
+        # add snmpOutNoSuchNames and expect sysDescr & snmpOutNoSuchNames
+        # to be in the OID DB
+
+        oidDb.add('SNMPv2-MIB', 'snmpOutNoSuchNames', 0, value=123,
+                  bdsMappingFunc=__class__)
+
+        expected = rfc1902.ObjectIdentifier('1.3.6.1.2.1.1.1.0')
+
+        oidItem = oidDb.getObjFromOid(expected)
+
+        self.assertEqual(expected, oidItem.oid)
+
+        expected = rfc1902.ObjectIdentifier('1.3.6.1.2.1.11.21.0')
+
+        oidItem = oidDb.getObjFromOid(expected)
+
+        self.assertEqual(expected, oidItem.oid)
+
+        mock_time.return_value = 122
+
+        # update snmpOutNoSuchNames, but expect sysDescr to still be there
+
+        oidDb.add('SNMPv2-MIB', 'snmpOutNoSuchNames', 0, value=123,
+                  bdsMappingFunc=__class__)
+
+        expected = rfc1902.ObjectIdentifier('1.3.6.1.2.1.1.1.0')
+
+        oidItem = oidDb.getObjFromOid(expected)
+
+        self.assertEqual(expected, oidItem.oid)
+
+        expected = rfc1902.ObjectIdentifier('1.3.6.1.2.1.11.21.0')
+
+        oidItem = oidDb.getObjFromOid(expected)
+
+        self.assertEqual(expected, oidItem.oid)
+
     def test_getNextOid(self):
         for idx, oid in enumerate(self.OIDS[:-1]):
             nextOid = self.oidDb.getNextOid(oid)

--- a/tests/unit/test_snmp_notificator.py
+++ b/tests/unit/test_snmp_notificator.py
@@ -146,14 +146,14 @@ bdsSnmpAdapter:
 
         expectedVarBinds = [
             (rfc1902.ObjectIdentifier('1.3.6.1.2.1.1.3.0'), mock.ANY),
-            (rfc1902.ObjectIdentifier('1.3.6.1.6.3.1.1.4.1.0'), rfc1902.ObjectIdentifier('1.3.6.1.4.1.50058.103.1.1')),
+            (rfc1902.ObjectIdentifier('1.3.6.1.6.3.1.1.4.1.0'), rfc1902.ObjectIdentifier('1.3.6.1.4.1.50058.103.1.0.1.1')),
             (rfc1902.ObjectIdentifier('1.3.6.1.4.1.50058.104.2.1.1.0'), rfc1902.Integer32(1)),
             (rfc1902.ObjectIdentifier('1.3.6.1.4.1.50058.104.2.1.2.0'), rfc1902.OctetString('error')),
             (rfc1902.ObjectIdentifier('1.3.6.1.4.1.50058.104.2.1.3.0'), rfc1902.Integer32(0)),
             (rfc1902.ObjectIdentifier('1.3.6.1.4.1.50058.104.2.1.4.0'), rfc1902.OctetString('error')),
         ]
 
-        ntf.ntfOrg.sendVarBinds.assert_called_once_with(
+        ntf._ntfOrg.sendVarBinds.assert_called_once_with(
             mock_snmpEngine, mock.ANY, None, '', expectedVarBinds, mock.ANY)
 
 


### PR DESCRIPTION
When adding managed objects into the OID DB, allow disabling them to ever expire. Use this feature for predefined OIDs to make sure they stay in thr OID DB forever.
