### PR TITLE
01 - Add support for f-strings in Python <3.6

### DIFF
--- a/bdssnmpadaptor/access.py
+++ b/bdssnmpadaptor/access.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/commands/__init__.py
+++ b/bdssnmpadaptor/commands/__init__.py
@@ -1,0 +1,1 @@
+# -*- coding: future_fstrings -*-

--- a/bdssnmpadaptor/commands/adaptor.py
+++ b/bdssnmpadaptor/commands/adaptor.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/commands/graylogTestClient.py
+++ b/bdssnmpadaptor/commands/graylogTestClient.py
@@ -1,3 +1,4 @@
+# -*- coding: future_fstrings -*-
 from pygelf import GelfHttpHandler
 import logging
 

--- a/bdssnmpadaptor/config.py
+++ b/bdssnmpadaptor/config.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/daemon.py
+++ b/bdssnmpadaptor/daemon.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/error.py
+++ b/bdssnmpadaptor/error.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/log.py
+++ b/bdssnmpadaptor/log.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_functions.py
+++ b/bdssnmpadaptor/mapping_functions.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/confd_global_interface_container.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_interface_container.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/confd_global_interface_physical.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_interface_physical.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/confd_global_startup_status_confd.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_startup_status_confd.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/confd_local_system_software_info_confd.py
+++ b/bdssnmpadaptor/mapping_modules/confd_local_system_software_info_confd.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/ffwd_default_interface_logical.py
+++ b/bdssnmpadaptor/mapping_modules/ffwd_default_interface_logical.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/fwdd_global_interface_physical_statistics.py
+++ b/bdssnmpadaptor/mapping_modules/fwdd_global_interface_physical_statistics.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
+++ b/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/predefined_oids.py
+++ b/bdssnmpadaptor/mapping_modules/predefined_oids.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mib_controller.py
+++ b/bdssnmpadaptor/mib_controller.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/oid_db.py
+++ b/bdssnmpadaptor/oid_db.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/rest_server.py
+++ b/bdssnmpadaptor/rest_server.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/snmp_config.py
+++ b/bdssnmpadaptor/snmp_config.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/snmp_notificator.py
+++ b/bdssnmpadaptor/snmp_notificator.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/snmp_responder.py
+++ b/bdssnmpadaptor/snmp_responder.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pysnmp>=4.4.8,<5.0.0
 aiohttp
 requests
 pyyaml
+future-fstrings

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ Topic :: Software Development :: Libraries :: Python Modules
 
 requires = open('requirements.txt').read()
 
-if sys.version_info[:2] < (3, 6):
-    print("ERROR: this package requires Python 3.6 or later!")
+if sys.version_info[:3] < (3, 5, 3):
+    print("ERROR: this package requires Python 3.5.3 or later!")
     sys.exit(1)
 
 try:


### PR DESCRIPTION
This change adds a conditional dependency on the `future-fstrings` module which supports f-strings in older Pythons.