### PR TITLE
03 -  Fix interface count and improve expiration mechanics     

### DIFF
--- a/bdssnmpadaptor/access.py
+++ b/bdssnmpadaptor/access.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/commands/__init__.py
+++ b/bdssnmpadaptor/commands/__init__.py
@@ -1,0 +1,1 @@
+# -*- coding: future_fstrings -*-

--- a/bdssnmpadaptor/commands/adaptor.py
+++ b/bdssnmpadaptor/commands/adaptor.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/commands/graylogTestClient.py
+++ b/bdssnmpadaptor/commands/graylogTestClient.py
@@ -1,3 +1,4 @@
+# -*- coding: future_fstrings -*-
 from pygelf import GelfHttpHandler
 import logging
 

--- a/bdssnmpadaptor/config.py
+++ b/bdssnmpadaptor/config.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/daemon.py
+++ b/bdssnmpadaptor/daemon.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/error.py
+++ b/bdssnmpadaptor/error.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/log.py
+++ b/bdssnmpadaptor/log.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_functions.py
+++ b/bdssnmpadaptor/mapping_functions.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/confd_global_interface_container.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_interface_container.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/confd_global_interface_container.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_interface_container.py
@@ -93,59 +93,63 @@ class ConfdGlobalInterfaceContainer(object):
 
         currentSysTime = int((time.time() - birthday) * 100)
 
-        with oidDb.module(__name__) as add:
+        add = oidDb.add
 
-            add('IF-MIB', 'ifNumber', 0, value=len(bdsData['objects']))
+        for i, bdsObject in enumerate(bdsData['objects']):
 
-            for i, bdsObject in enumerate(bdsData['objects']):
+            ifName = bdsObject['attribute']['interface_name']
 
-                ifName = bdsObject['attribute']['interface_name']
+            index = mapping_functions.ifIndexFromIfName(ifName)
 
-                index = mapping_functions.ifIndexFromIfName(ifName)
+            ifSpeed = IFSPEED_LAMBDA(bdsObject['attribute']['bandwidth'])
 
-                ifSpeed = IFSPEED_LAMBDA(bdsObject['attribute']['bandwidth'])
+            if ifSpeed == 100000000:
+                ifGigEtherName = 'hundredGe-' + mapping_functions.stripIfPrefixFromIfName(ifName)
 
-                if ifSpeed == 100000000:
-                    ifGigEtherName = 'hundredGe-' + mapping_functions.stripIfPrefixFromIfName(ifName)
+            elif ifSpeed == 10000000:
+                ifGigEtherName = 'tenGe-' + mapping_functions.stripIfPrefixFromIfName(ifName)
 
-                elif ifSpeed == 10000000:
-                    ifGigEtherName = 'tenGe-' + mapping_functions.stripIfPrefixFromIfName(ifName)
+            else:
+                ifGigEtherName = 'ge-' + mapping_functions.stripIfPrefixFromIfName(ifName)
 
-                else:
-                    ifGigEtherName = 'ge-' + mapping_functions.stripIfPrefixFromIfName(ifName)
+            add('IF-MIB', 'ifIndex', index, value=index)
 
-                add('IF-MIB', 'ifIndex', index, value=index)
+            add('IF-MIB', 'ifDescr', index, value=ifGigEtherName)
 
-                add('IF-MIB', 'ifDescr', index, value=ifGigEtherName)
+            add('IF-MIB', 'ifType', index,
+                value=IFTYPEMAP[int(bdsObject['attribute']['encapsulation_type'])])
 
-                add('IF-MIB', 'ifType', index,
-                    value=IFTYPEMAP[int(bdsObject['attribute']['encapsulation_type'])])
+            add('IF-MIB', 'ifMtu', index,
+                value=IFMTU_LAMBDA(bdsObject['attribute']['layer2_mtu']))
 
-                add('IF-MIB', 'ifMtu', index,
-                    value=IFMTU_LAMBDA(bdsObject['attribute']['layer2_mtu']))
+            add('IF-MIB', 'ifPhysAddress', index,
+                value=bdsObject['attribute']['mac_address'].replace(':', ''),
+                valueFormat='hexValue')
 
-                add('IF-MIB', 'ifPhysAddress', index,
-                    value=bdsObject['attribute']['mac_address'].replace(':', ''),
-                    valueFormat='hexValue')
+            add('IF-MIB', 'ifAdminStatus', index,
+                value=bdsObject['attribute']['admin_status'])
 
-                add('IF-MIB', 'ifAdminStatus', index,
-                    value=bdsObject['attribute']['admin_status'])
+            add('IF-MIB', 'ifOperStatus', index,
+                value=IFOPERSTATUSMAP[int(bdsObject['attribute']['link_status'])])
 
-                add('IF-MIB', 'ifOperStatus', index,
-                    value=IFOPERSTATUSMAP[int(bdsObject['attribute']['link_status'])])
+            add('IF-MIB', 'ifSpeed', index,
+                value=IFSPEED_LAMBDA(bdsObject['attribute']['bandwidth']))
 
-                add('IF-MIB', 'ifSpeed', index,
-                    value=IFSPEED_LAMBDA(bdsObject['attribute']['bandwidth']))
+            if i < len(bdsIds):
+                # possible table entry change
+                ifLastChange = None if newBdsIds[i] == bdsIds[i] else currentSysTime
 
-                if i < len(bdsIds):
-                    # possible table entry change
-                    ifLastChange = None if newBdsIds[i] == bdsIds[i] else currentSysTime
+            else:
+                # initial run or table size change
+                ifLastChange = 0 if bdsIds else currentSysTime
 
-                else:
-                    # initial run or table size change
-                    ifLastChange = 0 if bdsIds else currentSysTime
+            add('IF-MIB', 'ifLastChange', index, value=ifLastChange)
 
-                add('IF-MIB', 'ifLastChange', index, value=ifLastChange)
+        # count *all* IF-MIB interfaces we currently have - some
+        # may be contributed by other modules
+        ifNumber = len(oidDb.getObjectsByName('IF-MIB', 'ifIndex'))
+
+        add('IF-MIB', 'ifNumber', 0, value=ifNumber)
 
         add('IF-MIB', 'ifStackLastChange', 0,
             value=currentSysTime if bdsIds else 0)

--- a/bdssnmpadaptor/mapping_modules/confd_global_interface_physical.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_interface_physical.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/confd_global_startup_status_confd.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_startup_status_confd.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/confd_global_startup_status_confd.py
+++ b/bdssnmpadaptor/mapping_modules/confd_global_startup_status_confd.py
@@ -68,26 +68,26 @@ class ConfdGlobalStartupStatusConfd(object):
         if newBdsIds == bdsIds:
             return
 
-        with oidDb.module(__name__) as add:
+        add = oidDb.add
 
-            for index0, bdsJsonObject in enumerate(bdsData['objects']):
-                index = index0 + 1
+        for index0, bdsJsonObject in enumerate(bdsData['objects']):
+            index = index0 + 1
 
-                add('HOST-RESOURCES-MIB', 'hrSWOSIndex', index, value=index)
+            add('HOST-RESOURCES-MIB', 'hrSWOSIndex', index, value=index)
 
-                add('HOST-RESOURCES-MIB', 'hrSWRunName', index,
-                    value=bdsJsonObject['attribute']['module_name'])
+            add('HOST-RESOURCES-MIB', 'hrSWRunName', index,
+                value=bdsJsonObject['attribute']['module_name'])
 
-                add('HOST-RESOURCES-MIB', 'hrSWRunID', index, value='0.0')
+            add('HOST-RESOURCES-MIB', 'hrSWRunID', index, value='0.0')
 
-                add('HOST-RESOURCES-MIB', 'hrSWRunPath', index,
-                    value=bdsJsonObject['attribute']['bd_name'])
+            add('HOST-RESOURCES-MIB', 'hrSWRunPath', index,
+                value=bdsJsonObject['attribute']['bd_name'])
 
-                add('HOST-RESOURCES-MIB', 'hrSWRunParameters', index, value='')
+            add('HOST-RESOURCES-MIB', 'hrSWRunParameters', index, value='')
 
-                add('HOST-RESOURCES-MIB', 'hrSWRunType', index, value=4)  # 4 - application
+            add('HOST-RESOURCES-MIB', 'hrSWRunType', index, value=4)  # 4 - application
 
-                add('HOST-RESOURCES-MIB', 'hrSWRunStatus', index,
-                    value=HRSWRUNSTATUSMAP[int(bdsJsonObject['attribute']['startup_status'])])
+            add('HOST-RESOURCES-MIB', 'hrSWRunStatus', index,
+                value=HRSWRUNSTATUSMAP[int(bdsJsonObject['attribute']['startup_status'])])
 
         bdsIds[:] = newBdsIds

--- a/bdssnmpadaptor/mapping_modules/confd_local_system_software_info_confd.py
+++ b/bdssnmpadaptor/mapping_modules/confd_local_system_software_info_confd.py
@@ -67,39 +67,39 @@ class ConfdLocalSystemSoftwareInfoConfd(object):
 
         swString = mapping_functions.stringFromSoftwareInfo(bdsData)
 
-        with oidDb.module(__name__) as add:
+        add = oidDb.add
 
-            add('SNMPv2-MIB', 'sysDescr', 0, value=swString)
+        add('SNMPv2-MIB', 'sysDescr', 0, value=swString)
 
-            # for index,bdsJsonObject in enumerate(bdsData['objects"]):
-            #     #indexString = bdsJsonObject["attribute"]["library"]
-            #     #indexCharList = [str(ord(c)) for c in indexString]
-            #     #index = str(len(indexCharList)) + "." + ".".join(indexCharList)  # FIXME add description
-            #
-            #     add('HOST-RESOURCES-MIB', 'hrSWRunIndex', index, value=index)
-            #
-            #     add('HOST-RESOURCES-MIB', 'hrSWRunName', index,
-            #          value=bdsJsonObject["attribute"]["commit_id"])
+        # for index,bdsJsonObject in enumerate(bdsData['objects"]):
+        #     #indexString = bdsJsonObject["attribute"]["library"]
+        #     #indexCharList = [str(ord(c)) for c in indexString]
+        #     #index = str(len(indexCharList)) + "." + ".".join(indexCharList)  # FIXME add description
+        #
+        #     add('HOST-RESOURCES-MIB', 'hrSWRunIndex', index, value=index)
+        #
+        #     add('HOST-RESOURCES-MIB', 'hrSWRunName', index,
+        #          value=bdsJsonObject["attribute"]["commit_id"])
 
-            #     add('HOST-RESOURCES-MIB', 'commitDate', index,
-            #         value=bdsJsonObject["attribute"]["commit_date"])
+        #     add('HOST-RESOURCES-MIB', 'commitDate', index,
+        #         value=bdsJsonObject["attribute"]["commit_date"])
 
-            #     add('HOST-RESOURCES-MIB', 'packageDate', index,
-            #         value=bdsJsonObject["attribute"]["package_date"])
+        #     add('HOST-RESOURCES-MIB', 'packageDate', index,
+        #         value=bdsJsonObject["attribute"]["package_date"])
 
-            #     add('HOST-RESOURCES-MIB', 'vcCheckout', index,
-            #         value=bdsJsonObject["attribute"]["vc_checkout"])
+        #     add('HOST-RESOURCES-MIB', 'vcCheckout', index,
+        #         value=bdsJsonObject["attribute"]["vc_checkout"])
 
-            #     add('HOST-RESOURCES-MIB', 'branch', index,
-            #         value=bdsJsonObject["attribute"]["branch"])
+        #     add('HOST-RESOURCES-MIB', 'branch', index,
+        #         value=bdsJsonObject["attribute"]["branch"])
 
-            #     add('HOST-RESOURCES-MIB', 'libraryVersion', index,
-            #         value=bdsJsonObject["attribute"]["version"])
+        #     add('HOST-RESOURCES-MIB', 'libraryVersion', index,
+        #         value=bdsJsonObject["attribute"]["version"])
 
-            #     add('HOST-RESOURCES-MIB', 'sourcePath', index,
-            #         value=bdsJsonObject["attribute"]["source_path"])
+        #     add('HOST-RESOURCES-MIB', 'sourcePath', index,
+        #         value=bdsJsonObject["attribute"]["source_path"])
 
-            # # in addition the SW Info Flag is set by
-            # # creating an abbreviated string over all modules
+        # # in addition the SW Info Flag is set by
+        # # creating an abbreviated string over all modules
 
         bdsIds[:] = newBdsIds

--- a/bdssnmpadaptor/mapping_modules/confd_local_system_software_info_confd.py
+++ b/bdssnmpadaptor/mapping_modules/confd_local_system_software_info_confd.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/ffwd_default_interface_logical.py
+++ b/bdssnmpadaptor/mapping_modules/ffwd_default_interface_logical.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/ffwd_default_interface_logical.py
+++ b/bdssnmpadaptor/mapping_modules/ffwd_default_interface_logical.py
@@ -63,19 +63,25 @@ class FfwdDefaultInterfaceLogical(object):
         if newBdsIds == bdsIds:
             return
 
-        with oidDb.module(__name__) as add:
+        add = oidDb.add
 
-            for bdsJsonObject in bdsData['objects']:
+        for bdsJsonObject in bdsData['objects']:
 
-                ifName = bdsJsonObject['attribute']['interface_name']
+            ifName = bdsJsonObject['attribute']['interface_name']
 
-                index = mapping_functions.ifIndexFromIfName(ifName)
+            index = mapping_functions.ifIndexFromIfName(ifName)
 
-                add('IF-MIB', 'ifIndex', index, value=index)
+            add('IF-MIB', 'ifIndex', index, value=index)
 
-                add('IF-MIB', 'ifDescr', index,
-                    value=bdsJsonObject['attribute']['interface_name'])
+            add('IF-MIB', 'ifDescr', index,
+                value=bdsJsonObject['attribute']['interface_name'])
 
-                add('IF-MIB', 'ifType', index, value=6)
+            add('IF-MIB', 'ifType', index, value=6)
+
+        # count *all* IF-MIB interfaces we currently have - some
+        # may be contributed by other modules
+        ifNumber = len(oidDb.getObjectsByName('IF-MIB', 'ifIndex'))
+
+        add('IF-MIB', 'ifNumber', 0, value=ifNumber)
 
         bdsIds[:] = newBdsIds

--- a/bdssnmpadaptor/mapping_modules/fwdd_global_interface_physical_statistics.py
+++ b/bdssnmpadaptor/mapping_modules/fwdd_global_interface_physical_statistics.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/fwdd_global_interface_physical_statistics.py
+++ b/bdssnmpadaptor/mapping_modules/fwdd_global_interface_physical_statistics.py
@@ -149,50 +149,56 @@ class FwddGlobalInterfacePhysicalStatistics(object):
         if newBdsIds == bdsIds:
             return
 
-        with oidDb.module(__name__) as add:
+        add = oidDb.add
 
-            for i, bdsJsonObject in enumerate(bdsData['objects']):
+        for i, bdsJsonObject in enumerate(bdsData['objects']):
 
-                attribute = bdsJsonObject['attribute']
+            attribute = bdsJsonObject['attribute']
 
-                ifName = attribute['interface_name']
+            ifName = attribute['interface_name']
 
-                index = mapping_functions.ifIndexFromIfName(ifName)
+            index = mapping_functions.ifIndexFromIfName(ifName)
 
-                add('IF-MIB', 'ifInOctets', index,
-                    value=LELL_LAMBDA(attribute['port_stat_if_in_octets']))
+            add('IF-MIB', 'ifInOctets', index,
+                value=LELL_LAMBDA(attribute['port_stat_if_in_octets']))
 
-                add('IF-MIB', 'ifInUcastPkts', index,
-                    value=LELL_LAMBDA(attribute['port_stat_if_in_ucast_pkts']))
+            add('IF-MIB', 'ifInUcastPkts', index,
+                value=LELL_LAMBDA(attribute['port_stat_if_in_ucast_pkts']))
 
-                add('IF-MIB', 'ifInNUcastPkts', index,
-                    value=LELL_LAMBDA(attribute['port_stat_if_in_non_ucast_pkts']))
+            add('IF-MIB', 'ifInNUcastPkts', index,
+                value=LELL_LAMBDA(attribute['port_stat_if_in_non_ucast_pkts']))
 
-                add('IF-MIB', 'ifInDiscards', index,
-                    value=LELL_LAMBDA(attribute['port_stat_if_in_discards']))
+            add('IF-MIB', 'ifInDiscards', index,
+                value=LELL_LAMBDA(attribute['port_stat_if_in_discards']))
 
-                add('IF-MIB', 'ifInErrors', index,
-                    value=LELL_LAMBDA(attribute['port_stat_if_in_errors']))
+            add('IF-MIB', 'ifInErrors', index,
+                value=LELL_LAMBDA(attribute['port_stat_if_in_errors']))
 
-                add('IF-MIB', 'ifInUnknownProtos', index,
-                    value=LELL_LAMBDA(attribute['port_stat_if_in_unknown_protos']))
+            add('IF-MIB', 'ifInUnknownProtos', index,
+                value=LELL_LAMBDA(attribute['port_stat_if_in_unknown_protos']))
 
-                add('IF-MIB', 'ifOutOctets', index,
-                    value=LELL_LAMBDA(attribute['port_stat_if_out_octets']))
+            add('IF-MIB', 'ifOutOctets', index,
+                value=LELL_LAMBDA(attribute['port_stat_if_out_octets']))
 
-                add('IF-MIB', 'ifOutUcastPkts', index,
-                    value=LELL_LAMBDA(attribute['port_stat_if_out_ucast_pkts']))
+            add('IF-MIB', 'ifOutUcastPkts', index,
+                value=LELL_LAMBDA(attribute['port_stat_if_out_ucast_pkts']))
 
-                add('IF-MIB', 'ifOutNUcastPkts', index,
-                    value=LELL_LAMBDA(attribute['port_stat_if_out_non_ucast_pkts']))
+            add('IF-MIB', 'ifOutNUcastPkts', index,
+                value=LELL_LAMBDA(attribute['port_stat_if_out_non_ucast_pkts']))
 
-                add('IF-MIB', 'ifOutDiscards', index,
-                    value=LELL_LAMBDA(attribute['port_stat_if_out_discards']))
+            add('IF-MIB', 'ifOutDiscards', index,
+                value=LELL_LAMBDA(attribute['port_stat_if_out_discards']))
 
-                add('IF-MIB', 'ifOutErrors', index,
-                    value=LELL_LAMBDA(attribute['port_stat_if_out_errors']))
+            add('IF-MIB', 'ifOutErrors', index,
+                value=LELL_LAMBDA(attribute['port_stat_if_out_errors']))
 
-                add('IF-MIB', 'ifOutQLen', index,
-                    value=LELL_LAMBDA(attribute['port_stat_if_out_qlen']))
+            add('IF-MIB', 'ifOutQLen', index,
+                value=LELL_LAMBDA(attribute['port_stat_if_out_qlen']))
+
+        # count *all* IF-MIB interfaces we currently have - some
+        # may be contributed by other modules
+        ifNumber = len(oidDb.getObjectsByName('IF-MIB', 'ifIndex'))
+
+        add('IF-MIB', 'ifNumber', 0, value=ifNumber)
 
         bdsIds[:] = newBdsIds

--- a/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
+++ b/bdssnmpadaptor/mapping_modules/lldpd_global_lldp_intf_status.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/predefined_oids.py
+++ b/bdssnmpadaptor/mapping_modules/predefined_oids.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/mapping_modules/predefined_oids.py
+++ b/bdssnmpadaptor/mapping_modules/predefined_oids.py
@@ -175,13 +175,13 @@ class StaticAndPredefinedOids(object):
             BdsError: on OID DB population error
         """
 
-        with oidDb.module(__name__) as add:
+        add = oidDb.add
 
-            for objectName, objectInfo in staticOidDict.items():
-                mibName, mibSymbol = objectName.split('::', 1)
+        for objectName, objectInfo in staticOidDict.items():
+            mibName, mibSymbol = objectName.split('::', 1)
 
-                add(mibName, mibSymbol, 0, value=objectInfo.get('value'),
-                    code=objectInfo.get('code'))
+            add(mibName, mibSymbol, 0, value=objectInfo.get('value'),
+                code=objectInfo.get('code'))
 
         for i, phyValueList in enumerate(cls.ENT_PHYSICAL_TABLE):
 

--- a/bdssnmpadaptor/mib_controller.py
+++ b/bdssnmpadaptor/mib_controller.py
@@ -75,7 +75,7 @@ class MibInstrumController(instrum.AbstractMibInstrumController):
 
         for oid, value in varBinds:
             try:
-                oidDbItemObj = self._oidDb.getObjFromOid(str(oid))
+                oidDbItemObj = self._oidDb.getObjectByOid(str(oid))
 
             except Exception as exc:
                 self.moduleLogger.error(f'oidDb read failed for {oid}: {exc}')
@@ -111,7 +111,7 @@ class MibInstrumController(instrum.AbstractMibInstrumController):
                 f'request OID is {oid}, next OID is {nextOidString}')
 
             try:
-                oidDbItemObj = self._oidDb.getObjFromOid(nextOidString)
+                oidDbItemObj = self._oidDb.getObjectByOid(nextOidString)
 
             except Exception as exc:
                 self.moduleLogger.error(f'oidDb read failed for {oid}: {exc}')

--- a/bdssnmpadaptor/mib_controller.py
+++ b/bdssnmpadaptor/mib_controller.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/oid_db.py
+++ b/bdssnmpadaptor/oid_db.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/rest_server.py
+++ b/bdssnmpadaptor/rest_server.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/snmp_config.py
+++ b/bdssnmpadaptor/snmp_config.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/snmp_notificator.py
+++ b/bdssnmpadaptor/snmp_notificator.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/bdssnmpadaptor/snmp_notificator.py
+++ b/bdssnmpadaptor/snmp_notificator.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2017-2019, RtBrick Inc
 # License: BSD License 2.0
 #
+import asyncio
 import time
 
 from pysnmp.entity.rfc3413 import ntforg
@@ -168,7 +169,8 @@ class SnmpNotificationOriginator(object):
             f'{self._syslogMsgSeverity}=Integer32 '
             f'{self._syslogMsgText}=OctetString')
 
-    async def sendTrap(self, bdsLogDict):
+    @asyncio.coroutine
+    def sendTrap(self, bdsLogDict):
         self.moduleLogger.info(f'sendTrap bdsLogDict: {bdsLogDict}')
 
         self._trapCounter += 1
@@ -240,15 +242,16 @@ class SnmpNotificationOriginator(object):
         self.moduleLogger.info(
             f'notification {sendRequestHandle or ""} submitted')
 
-    async def run_forever(self):
+    @asyncio.coroutine
+    def run_forever(self):
 
         while True:
-            bdsLogToBeProcessed = await self._queue.get()
+            bdsLogToBeProcessed = yield from self._queue.get()
 
             self.moduleLogger.info(f'new log record: {bdsLogToBeProcessed}')
 
             try:
-                await self.sendTrap(bdsLogToBeProcessed)
+                yield from self.sendTrap(bdsLogToBeProcessed)
 
             except Exception as exc:
                 self.moduleLogger.error(f'TRAP not sent: {exc}')

--- a/bdssnmpadaptor/snmp_responder.py
+++ b/bdssnmpadaptor/snmp_responder.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- coding: future_fstrings -*-
 #
 # This file is part of bdsSnmpAdaptor software.
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pysnmp>=4.4.8,<5.0.0
 aiohttp
 requests
 pyyaml
+future-fstrings

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,10 @@
 pysnmp>=4.4.8,<5.0.0
-aiohttp
 requests
 pyyaml
 future-fstrings
+# pin aiohttp for Python 3.4+
+aiohttp<2.3.0
+# missing dependency in aiohttp->yarl
+typing
+# unconstrained dependency in aiohttp->yarl
+yarl<1.0.0

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ Topic :: Software Development :: Libraries :: Python Modules
 
 requires = open('requirements.txt').read()
 
-if sys.version_info[:3] < (3, 5, 3):
-    print("ERROR: this package requires Python 3.5.3 or later!")
+if sys.version_info[:2] < (3, 4):
+    print("ERROR: this package requires Python 3.4 or later!")
     sys.exit(1)
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ Topic :: Software Development :: Libraries :: Python Modules
 
 requires = open('requirements.txt').read()
 
-if sys.version_info[:2] < (3, 6):
-    print("ERROR: this package requires Python 3.6 or later!")
+if sys.version_info[:3] < (3, 5, 3):
+    print("ERROR: this package requires Python 3.5.3 or later!")
     sys.exit(1)
 
 try:

--- a/tests/integration/testBdsLoggingToSnmpNotification_async.py
+++ b/tests/integration/testBdsLoggingToSnmpNotification_async.py
@@ -8,7 +8,8 @@ DUT_REST_IP = "127.0.0.1"
 DUT_REST_PORT = 5000
 
 
-async def sendRequests():
+@asyncio.coroutine
+def sendRequests():
     httpRequestCounter = 0
 
     url = "http://{}:{}/dummyUrl".format(DUT_REST_IP, DUT_REST_PORT)

--- a/tests/unit/mapping_modules/test_ffwd_default_interface_logical.py
+++ b/tests/unit/mapping_modules/test_ffwd_default_interface_logical.py
@@ -46,6 +46,7 @@ class FfwdDefaultInterfaceLogicalTestCase(unittest.TestCase):
                 oids_in_db.append(oid)
 
         expected = [
+            '1.3.6.1.2.1.2.1.0',
             '1.3.6.1.2.1.2.2.1.1.528385',
             '1.3.6.1.2.1.2.2.1.2.528385',
             '1.3.6.1.2.1.2.2.1.3.528385'

--- a/tests/unit/mapping_modules/test_fwdd_global_interface_physical_statistics.py
+++ b/tests/unit/mapping_modules/test_fwdd_global_interface_physical_statistics.py
@@ -46,6 +46,7 @@ class FwddGlobalInterfacePhysicalStatisticsTestCase(unittest.TestCase):
                 oids_in_db.append(oid)
 
         expected = [
+            '1.3.6.1.2.1.2.1.0',
             '1.3.6.1.2.1.2.2.1.10.528384',
             '1.3.6.1.2.1.2.2.1.11.528384',
             '1.3.6.1.2.1.2.2.1.12.528384',

--- a/tests/unit/mapping_modules/test_predefined_oids.py
+++ b/tests/unit/mapping_modules/test_predefined_oids.py
@@ -58,7 +58,7 @@ pass
     def test_setOidsStaticValue(self):
         self.container.setOids(self.oidDb, self.STATIC_CONFIG, [], 0)
 
-        obj = self.oidDb.getObjFromOid(ObjectIdentifier('1.3.6.1.2.1.1.1.0'))
+        obj = self.oidDb.getObjectByOid(ObjectIdentifier('1.3.6.1.2.1.1.1.0'))
 
         self.assertEqual('l2.pod2.nbg2.rtbrick.net', str(obj.value))
         self.assertIsNone(obj.code)
@@ -66,7 +66,7 @@ pass
     def test_setOidsCodeValue(self):
         self.container.setOids(self.oidDb, self.STATIC_CONFIG, [], 0)
 
-        obj = self.oidDb.getObjFromOid(ObjectIdentifier('1.3.6.1.2.1.1.3.0'))
+        obj = self.oidDb.getObjectByOid(ObjectIdentifier('1.3.6.1.2.1.1.3.0'))
 
         self.assertIsInstance(obj.code, types.CodeType)
         self.assertEqual(0, obj.value)

--- a/tests/unit/test_access.py
+++ b/tests/unit/test_access.py
@@ -77,11 +77,14 @@ bdsSnmpAdapter:
             'confd_local.system.software.info.confd'],
         {'mappingFunc': asynctest.Mock(setOids=asynctest.CoroutineMock())})
     def test_run_forever(self, mock_predefined_oids, mock_http):
-        mock_session = mock_http.return_value.__aenter__.return_value
-        mock_response = mock_session.post.return_value.__aenter__.return_value
-        mock_response.json = asynctest.CoroutineMock(
+        mock_session = mock_http.return_value
+
+        mock_json = asynctest.CoroutineMock(
             return_value=self.JSON_RESPONSE)
-        mock_response.status = 200
+        mock_response = mock.MagicMock(
+            json=mock_json, status=200)
+        mock_session.post = asynctest.CoroutineMock(
+            return_value=mock_response)
 
         with asynctest.patch('asyncio.sleep') as sleep:
             sleep.side_effect = [lambda: 1, asyncio.CancelledError]

--- a/tests/unit/test_mib_controller.py
+++ b/tests/unit/test_mib_controller.py
@@ -59,12 +59,12 @@ class MibControllerTestCase(unittest.TestCase):
     def test_readVars(self):
         varBinds = [('1.3.6.1.2.1.1.0', 123)]
 
-        mock_oidItem = self.mock_oidDb.getObjFromOid.return_value
+        mock_oidItem = self.mock_oidDb.getObjectByOid.return_value
         mock_oidItem.code = None
 
         rspVarBinds = self.mc.readVars(varBinds)
 
-        self.mock_oidDb.getObjFromOid.assert_called_once_with(
+        self.mock_oidDb.getObjectByOid.assert_called_once_with(
             '1.3.6.1.2.1.1.0')
 
         expected = [
@@ -76,12 +76,12 @@ class MibControllerTestCase(unittest.TestCase):
         varBinds = [('1.3.6.1.2.1.1.0', 123)]
 
         mock_getNextOid = self.mock_oidDb.getNextOid.return_value
-        mock_oidItem = self.mock_oidDb.getObjFromOid.return_value
+        mock_oidItem = self.mock_oidDb.getObjectByOid.return_value
         mock_oidItem.code = None
 
         rspVarBinds = self.mc.readNextVars(varBinds)
 
-        self.mock_oidDb.getObjFromOid.assert_called_once_with(
+        self.mock_oidDb.getObjectByOid.assert_called_once_with(
             mock_getNextOid)
 
         expected = [

--- a/tests/unit/test_rest_server.py
+++ b/tests/unit/test_rest_server.py
@@ -90,17 +90,12 @@ bdsSnmpAdapter:
                 rs = rest_server.AsyncioRestServer(
                     mock.MagicMock(config={}), mock_queue)
 
-            mock_runner = mock_web.ServerRunner.return_value
-            mock_runner.setup = asynctest.CoroutineMock()
-
-            mock_site = mock_web.TCPSite.return_value
-            mock_site.start = asynctest.CoroutineMock()
+            self.my_loop.create_server = asynctest.CoroutineMock()
 
             self.my_loop.run_until_complete(rs.initialize())
 
-            mock_runner.setup.assert_called_once()
-
-            mock_site.start.assert_called_once()
+            mock_server = mock_web.Server
+            mock_server.assert_called_once()
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])


### PR DESCRIPTION
This change ensures that mapping modules populating interface table (of IF-MIB) count all interfaces when updating `ifNumber` object. That's because IF-MIB interface table is global.
    
Besides that the expiration logic is reworked in a way to expire entries by MIB object name rather than by mapping module name. The rationale is that we do not actually need to expire scalars, only tables because scalars almost never disappear in SNMP, while tabular objects can be very dynamic.
    
Given the above redesign, this change removes many unused methods and attributes from OID DB simplifying the code base.
