### PR TITLE
01 - Add more ways to get aiohttp client address

### DIFF
--- a/bdssnmpadaptor/rest_server.py
+++ b/bdssnmpadaptor/rest_server.py
@@ -57,12 +57,26 @@ class AsyncioRestServer(object):
             This coroutine queues the request and responds immediately even
             if further processing fails.
         """
-        peerIP = request._transport_peername[0]
+        # depending on aiohttp version, there can be different ways of
+        # getting remote address
+        try:
+            peer = request.remote
+
+        except AttributeError:
+            try:
+                peer = request._transport_peername
+
+            except AttributeError:
+                try:
+                    peer = request._transport._extra['peername']
+
+                except (AttributeError, KeyError):
+                    peer = 'unknown'
 
         self.requestCounter += 1
 
         self.moduleLogger.info(
-            f'handler: incoming request peerIP {peerIP}, headers '
+            f'handler: incoming request peer {peer}, headers '
             f'{request.headers}, count {self.requestCounter}')
 
         data = {

--- a/conf/bds-snmp-adaptor.yml
+++ b/conf/bds-snmp-adaptor.yml
@@ -2,6 +2,7 @@ bdsSnmpAdapter:
   loggingLevel: debug
   # Log to stdout unless log file is set here
   rotatingLogFile: /var/log/bds-snmp-adaptor
+  # Unless set, use new temporary directory on every invocation
   stateDir: /var/run/bds-snmp-adaptor
   # BDS REST API endpoints
   access:


### PR DESCRIPTION
It turns out, that depending on aiohttp version, there can be
more than one way of figuring out client network endpoint.

The best way is the `.remote` property, not only it is
documented, it also reads request headers what helps when
client resides behind an HTTP proxy.

However older aiohttp versions force us to use its internal,
non-documented attributes for the same purpose.