### PR TITLE
01 - Bind client SNMP socket to given local interface

### DIFF
--- a/conf/bds-snmp-adaptor.yml
+++ b/conf/bds-snmp-adaptor.yml
@@ -1,9 +1,9 @@
 bdsSnmpAdapter:
   loggingLevel: debug
   # Log to stdout unless log file is set here
-  rotatingLogFile: /var/log/bds-snmp-adaptor
+  #rotatingLogFile: /var/log/bds-snmp-adaptor
   # Unless set, use new temporary directory on every invocation
-  stateDir: /var/run/bds-snmp-adaptor
+  #stateDir: /var/run/bds-snmp-adaptor
   # BDS REST API endpoints
   access:
     rtbrickHost: 10.0.3.10

--- a/tests/unit/test_snmp_notificator.py
+++ b/tests/unit/test_snmp_notificator.py
@@ -78,6 +78,10 @@ bdsSnmpAdapter:
 
         self.mock_queue = mock.MagicMock
 
+        mock_snmp_config.setSnmpTransport.side_effect = [
+            (1, 2, 3), (1, 2, 4)
+        ]
+
         with mock.patch(
                 'bdssnmpadaptor.config.open',
                 side_effect=[io.StringIO(self.CONFIG),
@@ -92,8 +96,12 @@ bdsSnmpAdapter:
             engineId=mock.ANY)
         mock_snmp_config.setSnmpEngineBoots.assert_called_once_with(
             mock_snmpEngine, '/var/run/bds-snmp-responder')
-        mock_snmp_config.setSnmpTransport.assert_called_once_with(
-            mock_snmpEngine)
+        mock_snmp_config.setSnmpTransport.assert_any_call(
+            mock_snmpEngine, iface=('0.0.0.0', 0), iface_num=0,
+        )
+        mock_snmp_config.setSnmpTransport.assert_any_call(
+            mock_snmpEngine, iface=('127.0.0.1', 0), iface_num=1
+        )
         mock_snmp_config.setTrapTypeForTag.assert_called_once_with(
             mock_snmpEngine, 'mgrs')
 
@@ -118,9 +126,9 @@ bdsSnmpAdapter:
 
         mock_setTrapTargetAddress_calls = [
             mock.call(mock_snmpEngine, 'manager-B',
-                      ('127.0.0.1', 162), src=('0.0.0.0', 0), tag='mgrs'),
+                      (1, 2, 3), ('127.0.0.1', 162), tag='mgrs'),
             mock.call(mock_snmpEngine, 'user1',
-                      ('127.0.0.2', 162), src=('127.0.0.1', 0), tag='mgrs')
+                      (1, 2, 4), ('127.0.0.2', 162), tag='mgrs')
         ]
         mock_snmp_config.setTrapTargetAddress.assert_has_calls(
             mock_setTrapTargetAddress_calls)


### PR DESCRIPTION
This patch changes the way how client socket is initialized.
The end result is that for each SNMP target a dedicated socket
is created and bound to specific local endpoint given in the
configuration.

With this example configuration:

```
  snmpTrapTargets:  # array of SNMP trap targets
      target-I:  # descriptive name of this notification target
        bind-address: 127.0.0.2
        address: 127.0.0.1  # send SNMP trap to this address
        port: 162  # send SNMP trap to this port
        security-name: manager-B  # use this SNMP security name
      target-II:  # descriptive name of this notification target
        bind-address: 0.0.0.0
        address: 127.0.0.2  # send SNMP trap to this address
        port: 162  # send SNMP trap to this port
        security-name: user1  # use this SNMP security name
```

Actual network traffic looks like this (notice source addresses):

```

21:15:19.186865 IP 127.0.0.2.55870 > 127.0.0.1.162:  V2Trap(155)  .1.3.6.1.2.1.1.3.0=2961 .1.3.6.1.6.3.1.1.4.1.0=.1.3.6.1.4.1.50058.103.1.0.1.1 .1.3.6.1.4.1.50058.104.2.1.1.0=1 .1.3.6.1.4.1.50058.104.2.1.2.0="rtbrick" .1.3.6.1.4.1.50058.104.2.1.3.0=6 .1.3.6.1.4.1.50058.104.2.1.4.0="hello gelf"
21:15:19.190194 IP 127.0.0.1.56044 > 127.0.0.2.162:  F=a U="testUser1" E=_80_00_c3_8a_04_73_79_73_4e_61_6d_65_31_32_33 C="" V2Trap(155)  .1.3.6.1.2.1.1.3.0=2961 .1.3.6.1.6.3.1.1.4.1.0=.1.3.6.1.4.1.50058.103.1.0.1.1 .1.3.6.1.4.1.50058.104.2.1.1.0=1 .1.3.6.1.4.1.50058.104.2.1.2.0="rtbrick" .1.3.6.1.4.1.50058.104.2.1.3.0=6 .1.3.6.1.4.1.50058.104.2.1.4.0="hello gelf"
```